### PR TITLE
Address review feedback: include headers, timeout handling, and concurrency fixes

### DIFF
--- a/include/console_emulator.h
+++ b/include/console_emulator.h
@@ -32,7 +32,8 @@ private:
     mutable std::mutex displayMutex_;
 
     void printDisplay() const;
-    void printBorder() const;
+    void printTopBorder() const;
+    void printBottomBorder() const;
     std::string padLine(const std::string& line, size_t width) const;
 };
 
@@ -144,8 +145,9 @@ public:
 private:
     bool isConnected_;
     std::atomic<bool> isMeasuring_;
-    std::atomic<Volume> currentVolume_;
-    std::atomic<Volume> totalVolume_;
+    Volume currentVolume_;
+    Volume totalVolume_;
+    mutable std::mutex volumeMutex_;
     Volume flowRate_; // liters per second
     FlowCallback flowCallback_;
     std::thread simulationThread_;

--- a/include/controller.h
+++ b/include/controller.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <thread>
 
 namespace fuelflux {
 
@@ -129,6 +130,7 @@ private:
     // System state
     bool isRunning_;
     std::string lastErrorMessage_;
+    std::thread authThread_;
 
     // Helper methods
     void setupPeripheralCallbacks();

--- a/src/console_emulator.cpp
+++ b/src/console_emulator.cpp
@@ -50,20 +50,24 @@ void ConsoleDisplay::setBacklight(bool enabled) {
 
 void ConsoleDisplay::printDisplay() const {
     const size_t displayWidth = 40;
-    
+
     std::cout << "\n";
-    printBorder();
+    printTopBorder();
     std::cout << "│" << padLine(currentMessage_.line1, displayWidth) << "│\n";
     std::cout << "│" << padLine(currentMessage_.line2, displayWidth) << "│\n";
     std::cout << "│" << padLine(currentMessage_.line3, displayWidth) << "│\n";
     std::cout << "│" << padLine(currentMessage_.line4, displayWidth) << "│\n";
     std::cout << "│" << padLine(currentMessage_.line5, displayWidth) << "│\n";
-    printBorder();
+    printBottomBorder();
     std::cout << std::flush;
 }
 
-void ConsoleDisplay::printBorder() const {
+void ConsoleDisplay::printTopBorder() const {
     std::cout << "┌────────────────────────────────────────┐\n";
+}
+
+void ConsoleDisplay::printBottomBorder() const {
+    std::cout << "└────────────────────────────────────────┘\n";
 }
 
 std::string ConsoleDisplay::padLine(const std::string& line, size_t width) const {
@@ -313,16 +317,21 @@ void ConsoleFlowMeter::stopMeasurement() {
 }
 
 void ConsoleFlowMeter::resetCounter() {
-    currentVolume_ = 0.0;
+    {
+        std::lock_guard<std::mutex> lock(volumeMutex_);
+        currentVolume_ = 0.0;
+    }
     std::cout << "[FlowMeter] Counter reset" << std::endl;
     notifyFlowUpdate();
 }
 
 Volume ConsoleFlowMeter::getCurrentVolume() const {
+    std::lock_guard<std::mutex> lock(volumeMutex_);
     return currentVolume_;
 }
 
 Volume ConsoleFlowMeter::getTotalVolume() const {
+    std::lock_guard<std::mutex> lock(volumeMutex_);
     return totalVolume_;
 }
 
@@ -344,30 +353,50 @@ void ConsoleFlowMeter::simulationThreadFunction(Volume targetVolume) {
     const auto updateInterval = std::chrono::milliseconds(100);
     const Volume volumePerUpdate = flowRate_ * 0.1; // 100ms updates
     
-    while (!shouldStop_ && isMeasuring_ && currentVolume_ < targetVolume) {
+    while (!shouldStop_ && isMeasuring_) {
+        {
+            std::lock_guard<std::mutex> lock(volumeMutex_);
+            if (currentVolume_ >= targetVolume) {
+                break;
+            }
+        }
         std::this_thread::sleep_for(updateInterval);
-        
+
         if (!isMeasuring_) break;
-        
-        Volume newVolume = std::min(currentVolume_.load() + volumePerUpdate, targetVolume);
-        currentVolume_ = newVolume;
-        totalVolume_ = totalVolume_.load() + volumePerUpdate;
-        
+
+        Volume newVolume;
+        {
+            std::lock_guard<std::mutex> lock(volumeMutex_);
+            newVolume = std::min(currentVolume_ + volumePerUpdate, targetVolume);
+            currentVolume_ = newVolume;
+            totalVolume_ += volumePerUpdate;
+        }
+
         notifyFlowUpdate();
         
         std::cout << "[FlowMeter] Volume: " << std::fixed << std::setprecision(2) 
                   << newVolume << " L" << std::endl;
     }
     
-    if (currentVolume_ >= targetVolume) {
-        std::cout << "[FlowMeter] Target volume reached: " << targetVolume << " L" << std::endl;
+    {
+        std::lock_guard<std::mutex> lock(volumeMutex_);
+        if (currentVolume_ >= targetVolume) {
+            std::cout << "[FlowMeter] Target volume reached: " << targetVolume << " L" << std::endl;
+        }
     }
 }
 
 void ConsoleFlowMeter::notifyFlowUpdate() {
+    Volume current;
+    Volume total;
+    {
+        std::lock_guard<std::mutex> lock(volumeMutex_);
+        current = currentVolume_;
+        total = totalVolume_;
+    }
     std::lock_guard<std::mutex> lock(callbackMutex_);
     if (flowCallback_) {
-        flowCallback_(currentVolume_, totalVolume_);
+        flowCallback_(current, total);
     }
 }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <iomanip>
 #include <ctime>
+#include <thread>
 
 namespace fuelflux {
 
@@ -84,7 +85,11 @@ void Controller::shutdown() {
     if (pump_) pump_->shutdown();
     if (flowMeter_) flowMeter_->shutdown();
     if (cloudService_) cloudService_->shutdown();
-    
+
+    if (authThread_.joinable()) {
+        authThread_.join();
+    }
+
     std::cout << "[Controller] Shutdown complete" << std::endl;
 }
 
@@ -305,10 +310,12 @@ void Controller::requestAuthorization(const UserId& userId) {
     stateMachine_.processEvent(Event::CardPresented);
     
     auto future = cloudService_->authorizeUser(controllerId_, userId);
-    
-    // In a real implementation, this would be handled asynchronously
-    // For simplicity, we'll wait for the result
-    std::thread([this, future = std::move(future)]() mutable {
+
+    if (authThread_.joinable()) {
+        authThread_.join();
+    }
+
+    authThread_ = std::thread([this, future = std::move(future)]() mutable {
         try {
             AuthResponse response = future.get();
             handleAuthorizationResponse(response);
@@ -319,7 +326,7 @@ void Controller::requestAuthorization(const UserId& userId) {
             response.errorMessage = "Authorization service error";
             handleAuthorizationResponse(response);
         }
-    }).detach();
+    });
 }
 
 void Controller::handleAuthorizationResponse(const AuthResponse& response) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <thread>
 #include <atomic>
+#include <cstdlib>
 #include <signal.h>
 
 using namespace fuelflux;

--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -25,8 +25,10 @@ bool StateMachine::processEvent(Event event) {
         return false;
     }
 
-    // Check for timeout first
-    checkTimeout();
+    // Check for timeout unless we're already handling one
+    if (event != Event::Timeout) {
+        checkTimeout();
+    }
 
     auto key = std::make_pair(currentState_, event);
     auto it = transitions_.find(key);
@@ -271,6 +273,7 @@ void StateMachine::checkTimeout() {
     
     if (elapsed >= TIMEOUT_DURATION) {
         processEvent(Event::Timeout);
+        updateActivityTime();
     }
 }
 


### PR DESCRIPTION
## Summary
- include <cstdlib> for getenv and <thread> for std::thread
- prevent recursive timeouts and refine console display borders
- guard flow meter volume updates and manage authorization thread safely

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68be0398bc508321a000e3b61fb8dff1