### PR TITLE
Backend: track backend error codes and preserve backend error text

### DIFF
--- a/include/backend.h
+++ b/include/backend.h
@@ -65,14 +65,21 @@ public:
 
 private:
     // Private method for common parsing of responses from the backend
-    // Returns: true on success, false on failure (sets lastError_ and lastErrorCode_)
+    // Returns: true on success, false on backend-reported errors (CodeError != 0)
     // On success, responseOut is populated with the parsed JSON
-    // Throws exception only for internal/unexpected errors
+    // On backend error (false return), lastError_ and lastErrorCode_ are populated
+    // with the backend-provided error details; callers should check GetLastError()
+    // and GetLastErrorCode() for diagnostic information
+    // Throws exception only for internal/unexpected errors (HTTP failures, parse errors, etc.)
     bool HttpRequestWrapper(const std::string& endpoint, 
                             const std::string& method,
                             const nlohmann::json& requestBody,
                             nlohmann::json& responseOut,
                             bool useBearerToken = false);
+
+    // Helper method to clear authorization state
+    // If clearErrorState is true, also clears lastError_ and lastErrorCode_
+    void ClearAuthState(bool clearErrorState = false);
 
     // Base URL of backend REST API
     std::string baseAPI_;

--- a/src/backend.cpp
+++ b/src/backend.cpp
@@ -236,13 +236,26 @@ bool Backend::HttpRequestWrapper(const std::string& endpoint,
     } 
     catch (const std::exception& e) {
         // Internal/unexpected errors - set error state and re-throw
-        if (lastError_.empty()) {
-            lastError_ = e.what();
-        }
-        if (lastErrorCode_ == 0) {
-            lastErrorCode_ = -1;
-        }
+        lastError_ = e.what();
+        lastErrorCode_ = -1;
         throw;
+    }
+}
+
+// Helper method to clear authorization state variables.
+// When clearErrorState is true, also resets lastError_ and lastErrorCode_ to indicate success.
+// When false, preserves the current error state (used when clearing state due to errors).
+void Backend::ClearAuthState(bool clearErrorState) {
+    token_.clear();
+    roleId_ = 0;
+    allowance_ = 0.0;
+    price_ = 0.0;
+    fuelTanks_.clear();
+    isAuthorized_ = false;
+    
+    if (clearErrorState) {
+        lastError_.clear();
+        lastErrorCode_ = 0;
     }
 }
 
@@ -337,12 +350,8 @@ bool Backend::Authorize(const std::string& uid) {
     } 
     catch (const std::exception& e) {
         LOG_BCK_ERROR("Authorization failed: {}", e.what());
-        if (lastError_.empty()) {
-            lastError_ = StdControllerError;
-        }
-        if (lastErrorCode_ == 0) {
-            lastErrorCode_ = -1;
-        }
+        lastError_ = StdControllerError;
+        lastErrorCode_ = -1;
         return false;
     }
 }
@@ -369,24 +378,12 @@ bool Backend::Deauthorize() {
             LOG_BCK_ERROR("Deauthorization failed with backend error code {}: {}", lastErrorCode_, lastError_);
             // On failure, clear state anyway since we can't recover from this
             // The backend may or may not have deauthorized us, so it's safer to clear our state
-            token_.clear();
-            roleId_ = 0;
-            allowance_ = 0.0;
-            price_ = 0.0;
-            fuelTanks_.clear();
-            isAuthorized_ = false;
+            ClearAuthState(false); // Don't clear error state - preserve backend error
             return false;
         }
         
-        // Clear instance variables only after successful deauthorization
-        token_.clear();
-        roleId_ = 0;
-        allowance_ = 0.0;
-        price_ = 0.0;
-        fuelTanks_.clear();
-        isAuthorized_ = false;
-        lastError_.clear();
-        lastErrorCode_ = 0;
+        // Clear instance variables and error state after successful deauthorization
+        ClearAuthState(true); // Clear error state too on success
         
         LOG_BCK_INFO("Deauthorization successful");
         
@@ -395,20 +392,11 @@ bool Backend::Deauthorize() {
     catch (const std::exception& e) {
         // On failure, clear state anyway since we can't recover from this
         // The backend may or may not have deauthorized us, so it's safer to clear our state
-        token_.clear();
-        roleId_ = 0;
-        allowance_ = 0.0;
-        price_ = 0.0;
-        fuelTanks_.clear();
-        isAuthorized_ = false;
+        ClearAuthState(false); // Don't clear error state - will be set below
         
         LOG_BCK_ERROR("Deauthorization failed: {} (state cleared for safety)", e.what());
-        if (lastError_.empty()) {
-            lastError_ = StdControllerError;
-        }
-        if (lastErrorCode_ == 0) {
-            lastErrorCode_ = -1;
-        }
+        lastError_ = StdControllerError;
+        lastErrorCode_ = -1;
         return false;
     }
 }
@@ -485,12 +473,8 @@ bool Backend::Refuel(TankNumber tankNumber, Volume volume) {
         return true;
     } catch (const std::exception& e) {
         LOG_BCK_ERROR("Failed to send refueling report: {}", e.what());
-        if (lastError_.empty()) {
-            lastError_ = StdBackendError;
-        }
-        if (lastErrorCode_ == 0) {
-            lastErrorCode_ = -1;
-        }
+        lastError_ = StdBackendError;
+        lastErrorCode_ = -1;
         return false;
     }
 }
@@ -566,12 +550,8 @@ bool Backend::Intake(TankNumber tankNumber, Volume volume, IntakeDirection direc
         return true;
     } catch (const std::exception& e) {
         LOG_BCK_ERROR("Failed to send fuel intake report: {}", e.what());
-        if (lastError_.empty()) {
-            lastError_ = StdBackendError;
-        }
-        if (lastErrorCode_ == 0) {
-            lastErrorCode_ = -1;
-        }
+        lastError_ = StdBackendError;
+        lastErrorCode_ = -1;
         return false;
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure that when the backend returns 200 OK but `CodeError != 0` we record the backend-provided `TextError` (or a Russian fallback) into `lastError_` and also persist the numeric code.  
- Expose the numeric backend error via a new accessor `GetLastErrorCode()`.  
- Ensure internal validation and exception paths set a sentinel error code (`-1`) while successful operations clear the code to `0`.  
- Prevent leaking backend/internal details by throwing a generic exception for application-level backend errors.

### Description

- Added `int lastErrorCode_` and `int GetLastErrorCode() const` to `Backend` in `include/backend.h`.  
- Introduced `UnknownBackendError = "Неизвестная  ошибка"` and initialized `lastErrorCode_` in the `Backend` constructor in `src/backend.cpp`.  
- Updated `HttpRequestWrapper` to, on `CodeError != 0`, set `lastErrorCode_` and `lastError_` to the backend `TextError` (or the fallback), and throw a generic `std::runtime_error("Backend error")`.  
- Propagated `lastErrorCode_ = -1` on internal validation/exception cases and `lastErrorCode_ = 0` on successful operations across `Authorize`, `Deauthorize`, `Refuel`, and `Intake`.

### Testing

- No automated tests were run for this change.  
- No CI or local build was executed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958b07109b08321983ad5f07cc3f831)