### PR TITLE
Add SQLite-backed backlog and background retry worker to Backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,9 @@ FetchContent_Declare(
 # Make dependencies available
 FetchContent_MakeAvailable(fmt nlohmann_json spdlog httplib)
 
+# SQLite3 dependency
+find_package(SQLite3 REQUIRED)
+
 # Conditional dependencies for real hardware
 if(TARGET_REAL_DISPLAY OR TARGET_REAL_CARD_READER)
     find_package(PkgConfig REQUIRED)
@@ -131,6 +134,7 @@ set(SOURCES
     src/peripherals/flow_meter.cpp
     src/console_emulator.cpp
     src/backend.cpp
+    src/backlog.cpp
 )
 
 # Add NHD library sources if TARGET_REAL_DISPLAY is enabled
@@ -159,6 +163,7 @@ set(HEADERS
     include/peripherals/peripheral_interface.h
     include/console_emulator.h
     include/backend.h
+    include/backlog.h
     include/types.h
 )
 
@@ -203,6 +208,7 @@ target_link_libraries(fuelflux
     nlohmann_json::nlohmann_json 
     spdlog::spdlog
     httplib::httplib
+    SQLite::SQLite3
 )
 
 # Link real hardware libraries if TARGET_REAL_DISPLAY is enabled
@@ -255,6 +261,7 @@ if(ENABLE_TESTING)
     # Test source files
     set(TEST_SOURCES
         tests/backend_test.cpp
+        tests/backlog_test.cpp
         tests/controller_test.cpp
     )
 
@@ -270,6 +277,7 @@ if(ENABLE_TESTING)
         src/peripherals/flow_meter.cpp
         src/console_emulator.cpp
         src/backend.cpp
+        src/backlog.cpp
     )
     
     # Add NHD library sources if TARGET_REAL_DISPLAY is enabled
@@ -302,6 +310,7 @@ if(ENABLE_TESTING)
         nlohmann_json::nlohmann_json
         spdlog::spdlog
         httplib::httplib
+        SQLite::SQLite3
     )
     
     # Link real hardware libraries if TARGET_REAL_DISPLAY is enabled

--- a/include/backlog.h
+++ b/include/backlog.h
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of fuelflux application
+
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+struct sqlite3;
+
+namespace fuelflux {
+
+enum class BacklogMethod {
+    Refuel,
+    Intake
+};
+
+struct BacklogItem {
+    std::int64_t id = 0;
+    std::string uid;
+    BacklogMethod method = BacklogMethod::Refuel;
+    std::string data;
+};
+
+class BacklogStore {
+public:
+    explicit BacklogStore(std::string dbPath);
+    ~BacklogStore();
+
+    bool Initialize();
+    bool Enqueue(const std::string& uid, BacklogMethod method, const std::string& data);
+    std::vector<BacklogItem> FetchAll();
+    bool Remove(std::int64_t id);
+    std::size_t Count() const;
+    const std::string& Path() const { return dbPath_; }
+
+private:
+    bool Execute(const std::string& statement) const;
+
+    std::string dbPath_;
+    mutable std::mutex mutex_;
+    ::sqlite3* db_ = nullptr;
+};
+
+} // namespace fuelflux

--- a/src/backlog.cpp
+++ b/src/backlog.cpp
@@ -1,0 +1,152 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of fuelflux application
+
+#include "backlog.h"
+#include "logger.h"
+#include <sqlite3.h>
+#include <utility>
+
+namespace fuelflux {
+
+namespace {
+
+const char* kCreateTableSql =
+    "CREATE TABLE IF NOT EXISTS backlog ("
+    "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+    "uid TEXT NOT NULL, "
+    "method INTEGER NOT NULL, "
+    "data TEXT NOT NULL"
+    ");";
+
+} // namespace
+
+BacklogStore::BacklogStore(std::string dbPath) : dbPath_(std::move(dbPath)) {}
+
+BacklogStore::~BacklogStore() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (db_) {
+        sqlite3_close(db_);
+        db_ = nullptr;
+    }
+}
+
+bool BacklogStore::Initialize() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (db_) {
+        return true;
+    }
+    if (sqlite3_open(dbPath_.c_str(), &db_) != SQLITE_OK) {
+        LOG_BCK_ERROR("Failed to open backlog database {}: {}", dbPath_, sqlite3_errmsg(db_));
+        sqlite3_close(db_);
+        db_ = nullptr;
+        return false;
+    }
+    if (!Execute(kCreateTableSql)) {
+        return false;
+    }
+    return true;
+}
+
+bool BacklogStore::Execute(const std::string& statement) const {
+    char* errMsg = nullptr;
+    if (sqlite3_exec(db_, statement.c_str(), nullptr, nullptr, &errMsg) != SQLITE_OK) {
+        std::string error = errMsg ? errMsg : "unknown sqlite error";
+        sqlite3_free(errMsg);
+        LOG_BCK_ERROR("Failed to execute sqlite statement: {}", error);
+        return false;
+    }
+    return true;
+}
+
+bool BacklogStore::Enqueue(const std::string& uid, BacklogMethod method, const std::string& data) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!db_ && !Initialize()) {
+        return false;
+    }
+    static const char* sql =
+        "INSERT INTO backlog (uid, method, data) VALUES (?1, ?2, ?3);";
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        LOG_BCK_ERROR("Failed to prepare backlog insert: {}", sqlite3_errmsg(db_));
+        return false;
+    }
+    sqlite3_bind_text(stmt, 1, uid.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 2, static_cast<int>(method));
+    sqlite3_bind_text(stmt, 3, data.c_str(), -1, SQLITE_TRANSIENT);
+
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    if (!ok) {
+        LOG_BCK_ERROR("Failed to insert backlog item: {}", sqlite3_errmsg(db_));
+    }
+    sqlite3_finalize(stmt);
+    return ok;
+}
+
+std::vector<BacklogItem> BacklogStore::FetchAll() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<BacklogItem> items;
+    if (!db_ && !Initialize()) {
+        return items;
+    }
+    static const char* sql =
+        "SELECT id, uid, method, data FROM backlog ORDER BY id;";
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        LOG_BCK_ERROR("Failed to prepare backlog select: {}", sqlite3_errmsg(db_));
+        return items;
+    }
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        BacklogItem item;
+        item.id = sqlite3_column_int64(stmt, 0);
+        const unsigned char* uid = sqlite3_column_text(stmt, 1);
+        item.uid = uid ? reinterpret_cast<const char*>(uid) : "";
+        item.method = static_cast<BacklogMethod>(sqlite3_column_int(stmt, 2));
+        const unsigned char* data = sqlite3_column_text(stmt, 3);
+        item.data = data ? reinterpret_cast<const char*>(data) : "";
+        items.push_back(std::move(item));
+    }
+    sqlite3_finalize(stmt);
+    return items;
+}
+
+bool BacklogStore::Remove(std::int64_t id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!db_ && !Initialize()) {
+        return false;
+    }
+    static const char* sql = "DELETE FROM backlog WHERE id = ?1;";
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        LOG_BCK_ERROR("Failed to prepare backlog delete: {}", sqlite3_errmsg(db_));
+        return false;
+    }
+    sqlite3_bind_int64(stmt, 1, id);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    if (!ok) {
+        LOG_BCK_ERROR("Failed to delete backlog item {}: {}", id, sqlite3_errmsg(db_));
+    }
+    sqlite3_finalize(stmt);
+    return ok;
+}
+
+std::size_t BacklogStore::Count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!db_) {
+        return 0;
+    }
+    static const char* sql = "SELECT COUNT(*) FROM backlog;";
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        LOG_BCK_ERROR("Failed to prepare backlog count: {}", sqlite3_errmsg(db_));
+        return 0;
+    }
+    std::size_t count = 0;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        count = static_cast<std::size_t>(sqlite3_column_int64(stmt, 0));
+    }
+    sqlite3_finalize(stmt);
+    return count;
+}
+
+} // namespace fuelflux

--- a/tests/backlog_test.cpp
+++ b/tests/backlog_test.cpp
@@ -1,0 +1,195 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of fuelflux application
+
+#include <gtest/gtest.h>
+#include "backend.h"
+#include "backlog.h"
+#include <httplib.h>
+#include <filesystem>
+
+using namespace fuelflux;
+
+namespace {
+
+class MockHTTPServer {
+public:
+    httplib::Server server;
+    std::thread serverThread;
+    int port = 0;
+    bool running = false;
+
+    std::atomic<int> authorizeCount{0};
+    std::atomic<int> deauthorizeCount{0};
+    std::atomic<int> refuelCount{0};
+    std::atomic<int> intakeCount{0};
+    std::atomic<int> roleId{1};
+
+    void start() {
+        if (running) return;
+        server.Post("/api/pump/authorize", [this](const httplib::Request&,
+                                                 httplib::Response& res) {
+            authorizeCount++;
+            nlohmann::json response;
+            response["Token"] = "token";
+            response["RoleId"] = roleId.load();
+            response["Allowance"] = 50.0;
+            response["Price"] = 1.0;
+            response["fuelTanks"] = nlohmann::json::array({{{"idTank", 1}, {"nameTank", "A"}}});
+            res.status = 200;
+            res.set_content(response.dump(), "application/json");
+        });
+        server.Post("/api/pump/deauthorize", [this](const httplib::Request&,
+                                                   httplib::Response& res) {
+            deauthorizeCount++;
+            res.status = 200;
+            res.set_content("{}", "application/json");
+        });
+        server.Post("/api/pump/refuel", [this](const httplib::Request&,
+                                              httplib::Response& res) {
+            refuelCount++;
+            res.status = 200;
+            res.set_content("{}", "application/json");
+        });
+        server.Post("/api/pump/fuel-intake", [this](const httplib::Request&,
+                                                   httplib::Response& res) {
+            intakeCount++;
+            res.status = 200;
+            res.set_content("{}", "application/json");
+        });
+        port = server.bind_to_any_port("127.0.0.1");
+        if (port == -1) {
+            throw std::runtime_error("Failed to bind to port");
+        }
+        running = true;
+        serverThread = std::thread([this]() { server.listen_after_bind(); });
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    void stop() {
+        if (!running) return;
+        server.stop();
+        if (serverThread.joinable()) {
+            serverThread.join();
+        }
+        running = false;
+    }
+
+    std::string baseUrl() const {
+        return "http://127.0.0.1:" + std::to_string(port);
+    }
+
+    ~MockHTTPServer() {
+        stop();
+    }
+};
+
+std::filesystem::path MakeTempDbPath(const std::string& name) {
+    auto path = std::filesystem::temp_directory_path() / name;
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+    return path;
+}
+
+} // namespace
+
+TEST(BacklogStoreTest, EnqueueFetchRemove) {
+    auto dbPath = MakeTempDbPath("fuelflux_backlog_store.sqlite");
+    BacklogStore store(dbPath.string());
+    EXPECT_TRUE(store.Initialize());
+    EXPECT_EQ(store.Count(), 0u);
+
+    EXPECT_TRUE(store.Enqueue("uid-1", BacklogMethod::Refuel, R"({"TankNumber":1})"));
+    EXPECT_TRUE(store.Enqueue("uid-2", BacklogMethod::Intake, R"({"TankNumber":2})"));
+    EXPECT_EQ(store.Count(), 2u);
+
+    auto items = store.FetchAll();
+    ASSERT_EQ(items.size(), 2u);
+    EXPECT_EQ(items[0].uid, "uid-1");
+    EXPECT_EQ(items[0].method, BacklogMethod::Refuel);
+    EXPECT_EQ(items[1].uid, "uid-2");
+    EXPECT_EQ(items[1].method, BacklogMethod::Intake);
+
+    EXPECT_TRUE(store.Remove(items[0].id));
+    EXPECT_EQ(store.Count(), 1u);
+    EXPECT_TRUE(store.Remove(items[1].id));
+    EXPECT_EQ(store.Count(), 0u);
+}
+
+TEST(BacklogStoreTest, PersistsAcrossInstances) {
+    auto dbPath = MakeTempDbPath("fuelflux_backlog_persist.sqlite");
+    {
+        BacklogStore store(dbPath.string());
+        EXPECT_TRUE(store.Initialize());
+        EXPECT_TRUE(store.Enqueue("uid-1", BacklogMethod::Refuel, R"({"TankNumber":1})"));
+    }
+    BacklogStore store(dbPath.string());
+    EXPECT_TRUE(store.Initialize());
+    EXPECT_EQ(store.Count(), 1u);
+    auto items = store.FetchAll();
+    ASSERT_EQ(items.size(), 1u);
+    EXPECT_EQ(items[0].uid, "uid-1");
+}
+
+TEST(BackendBacklogTest, EnqueuesOnNetworkFailure) {
+    auto dbPath = MakeTempDbPath("fuelflux_backlog_network.sqlite");
+    Backend backend("http://127.0.0.1:1", "controller", dbPath.string(),
+                    std::chrono::milliseconds(100));
+    backend.StopBacklogWorker();
+
+    EXPECT_FALSE(backend.Authorize("uid-1"));
+    EXPECT_EQ(backend.ProcessBacklogOnce(), false);
+
+    BacklogStore store(dbPath.string());
+    EXPECT_TRUE(store.Initialize());
+    EXPECT_EQ(store.Count(), 0u);
+
+    MockHTTPServer server;
+    server.start();
+    Backend connected(server.baseUrl(), "controller", dbPath.string(),
+                      std::chrono::milliseconds(100));
+    connected.StopBacklogWorker();
+    EXPECT_TRUE(connected.Authorize("uid-1"));
+    server.stop();
+    EXPECT_FALSE(connected.Refuel(1, 10.0));
+    EXPECT_EQ(store.Count(), 1u);
+}
+
+TEST(BackendBacklogTest, ProcessesRefuelBacklog) {
+    auto dbPath = MakeTempDbPath("fuelflux_backlog_process.sqlite");
+    BacklogStore store(dbPath.string());
+    EXPECT_TRUE(store.Initialize());
+    EXPECT_TRUE(store.Enqueue("uid-1", BacklogMethod::Refuel,
+                              R"({"TankNumber":1,"FuelVolume":10.0,"TimeAt":123})"));
+
+    MockHTTPServer server;
+    server.start();
+    Backend backend(server.baseUrl(), "controller", dbPath.string(),
+                    std::chrono::milliseconds(100));
+    backend.StopBacklogWorker();
+    EXPECT_TRUE(backend.ProcessBacklogOnce());
+    EXPECT_EQ(store.Count(), 0u);
+    EXPECT_EQ(server.authorizeCount.load(), 1);
+    EXPECT_EQ(server.refuelCount.load(), 1);
+    EXPECT_EQ(server.deauthorizeCount.load(), 1);
+}
+
+TEST(BackendBacklogTest, ProcessesIntakeBacklog) {
+    auto dbPath = MakeTempDbPath("fuelflux_backlog_process_intake.sqlite");
+    BacklogStore store(dbPath.string());
+    EXPECT_TRUE(store.Initialize());
+    EXPECT_TRUE(store.Enqueue("uid-2", BacklogMethod::Intake,
+                              R"({"TankNumber":1,"IntakeVolume":5.0,"Direction":1,"TimeAt":123})"));
+
+    MockHTTPServer server;
+    server.roleId = 2;
+    server.start();
+    Backend backend(server.baseUrl(), "controller", dbPath.string(),
+                    std::chrono::milliseconds(100));
+    backend.StopBacklogWorker();
+    EXPECT_TRUE(backend.ProcessBacklogOnce());
+    EXPECT_EQ(store.Count(), 0u);
+    EXPECT_EQ(server.authorizeCount.load(), 1);
+    EXPECT_EQ(server.intakeCount.load(), 1);
+    EXPECT_EQ(server.deauthorizeCount.load(), 1);
+}


### PR DESCRIPTION
### Motivation
- Persist outgoing reports that fail due to transient network errors so they can be retried later. 
- Ensure backlog is loaded on startup and processed in background without losing items across restarts. 
- Implement the required processing sequence for each backlog item: `Authorize` (using stored uid), `Refuel` or `Intake` (using stored data), then `Deauthorize`.

### Description
- Added a lightweight SQLite-backed backlog store: `include/backlog.h` and `src/backlog.cpp` implementing enqueue/fetch/remove/count and a single `backlog` table with `uid`, `method`, and `data` columns. 
- Extended `Backend` API (`include/backend.h`) to accept backlog DB path and interval, and added members and methods to manage backlog: `ProcessBacklogOnce`, `StartBacklogWorker`, `StopBacklogWorker`, `EnqueueBacklog`, `SendRefuelReport`, and `SendIntakeReport`.
- Implemented backlog logic in `src/backend.cpp`: network failures are detected and refuel/intake reports are enqueued to backlog when appropriate, and a background worker periodically fetches items and executes `Authorize` -> `Refuel`/`Intake` -> `Deauthorize` for each item, removing them on success.
- Integrated SQLite into the build by updating `CMakeLists.txt` and added unit tests `tests/backlog_test.cpp` covering enqueue/fetch/remove, persistence across instances, enqueuing on network failure, and processing refuel/intake backlog items.

### Testing
- Configured and built tests with `cmake -S . -B build -DENABLE_TESTING=ON -DTARGET_REAL_CARD_READER=OFF -DTARGET_REAL_DISPLAY=OFF` and `cmake --build build`, both succeeded. 
- Ran the full test suite with `ctest --test-dir build --output-on-failure` and all tests passed: `72/72` tests passed (including the new backlog tests). 
- Ran static checks with `clang-tidy -p build src/backend.cpp src/backlog.cpp tests/backlog_test.cpp` which completed without blocking errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e19bd67648321a241fda2affb903b)