### PR TITLE
Add SQLite-backed backlog storage and worker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,9 @@ FetchContent_Declare(
 # Make dependencies available
 FetchContent_MakeAvailable(fmt nlohmann_json spdlog httplib)
 
+# SQLite3 dependency
+find_package(SQLite3 REQUIRED)
+
 # Conditional dependencies for real hardware
 if(TARGET_REAL_DISPLAY OR TARGET_REAL_CARD_READER)
     find_package(PkgConfig REQUIRED)
@@ -131,6 +134,8 @@ set(SOURCES
     src/peripherals/flow_meter.cpp
     src/console_emulator.cpp
     src/backend.cpp
+    src/backlog_storage.cpp
+    src/backlog_worker.cpp
 )
 
 # Add NHD library sources if TARGET_REAL_DISPLAY is enabled
@@ -159,6 +164,8 @@ set(HEADERS
     include/peripherals/peripheral_interface.h
     include/console_emulator.h
     include/backend.h
+    include/backlog_storage.h
+    include/backlog_worker.h
     include/types.h
 )
 
@@ -203,6 +210,7 @@ target_link_libraries(fuelflux
     nlohmann_json::nlohmann_json 
     spdlog::spdlog
     httplib::httplib
+    SQLite::SQLite3
 )
 
 # Link real hardware libraries if TARGET_REAL_DISPLAY is enabled
@@ -255,6 +263,7 @@ if(ENABLE_TESTING)
     # Test source files
     set(TEST_SOURCES
         tests/backend_test.cpp
+        tests/backlog_test.cpp
         tests/controller_test.cpp
     )
 
@@ -270,6 +279,8 @@ if(ENABLE_TESTING)
         src/peripherals/flow_meter.cpp
         src/console_emulator.cpp
         src/backend.cpp
+        src/backlog_storage.cpp
+        src/backlog_worker.cpp
     )
     
     # Add NHD library sources if TARGET_REAL_DISPLAY is enabled
@@ -302,6 +313,7 @@ if(ENABLE_TESTING)
         nlohmann_json::nlohmann_json
         spdlog::spdlog
         httplib::httplib
+        SQLite::SQLite3
     )
     
     # Link real hardware libraries if TARGET_REAL_DISPLAY is enabled

--- a/include/backlog_storage.h
+++ b/include/backlog_storage.h
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of fuelflux application
+
+#pragma once
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "types.h"
+
+struct sqlite3;
+
+namespace fuelflux {
+
+struct BacklogItem {
+    int id = 0;
+    std::string uid;
+    BacklogMethod method = BacklogMethod::Refuel;
+    std::string data;
+};
+
+class BacklogStorage {
+public:
+    explicit BacklogStorage(const std::string& path);
+    ~BacklogStorage();
+
+    bool IsOpen() const;
+    bool AddItem(const std::string& uid, BacklogMethod method, const std::string& data);
+    std::vector<BacklogItem> LoadAll();
+    bool RemoveItem(int id);
+
+private:
+    bool Execute(const std::string& sql);
+    void Close();
+
+    sqlite3* db_;
+    std::mutex mutex_;
+};
+
+} // namespace fuelflux

--- a/include/backlog_worker.h
+++ b/include/backlog_worker.h
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of fuelflux application
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include "backend.h"
+#include "backlog_storage.h"
+
+namespace fuelflux {
+
+class BacklogWorker {
+public:
+    BacklogWorker(std::shared_ptr<BacklogStorage> storage,
+                  std::unique_ptr<IBackend> backend,
+                  std::chrono::milliseconds interval = std::chrono::seconds(5));
+    ~BacklogWorker();
+
+    void Start();
+    void Stop();
+    bool IsRunning() const;
+    bool ProcessOnce();
+
+private:
+    void RunLoop();
+    bool ProcessItem(const BacklogItem& item);
+
+    std::shared_ptr<BacklogStorage> storage_;
+    std::unique_ptr<IBackend> backend_;
+    std::chrono::milliseconds interval_;
+    std::thread workerThread_;
+    std::atomic<bool> running_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+};
+
+} // namespace fuelflux

--- a/include/controller.h
+++ b/include/controller.h
@@ -12,6 +12,8 @@
 #include <condition_variable>
 
 #include "backend.h"
+#include "backlog_storage.h"
+#include "backlog_worker.h"
 #include "state_machine.h"
 #include "types.h"
 #include "peripherals/peripheral_interface.h"
@@ -22,7 +24,10 @@ namespace fuelflux {
 // Main controller class that orchestrates the entire system
 class Controller {
   public:
-    Controller(ControllerId controllerId, std::unique_ptr<IBackend> backend = nullptr);
+    Controller(ControllerId controllerId,
+               std::unique_ptr<IBackend> backend = nullptr,
+               bool enableBacklog = true,
+               const std::string& backlogDbPath = "backlog.db");
     ~Controller();
 
     // System lifecycle
@@ -114,6 +119,8 @@ class Controller {
     std::unique_ptr<peripherals::IPump> pump_;
     std::unique_ptr<peripherals::IFlowMeter> flowMeter_;
     std::unique_ptr<IBackend> backend_;
+    std::shared_ptr<BacklogStorage> backlogStorage_;
+    std::unique_ptr<BacklogWorker> backlogWorker_;
     // Current session state
     UserInfo currentUser_;
     std::vector<TankInfo> availableTanks_;

--- a/include/types.h
+++ b/include/types.h
@@ -30,6 +30,11 @@ enum class IntakeDirection {
     Out = 2
 };
 
+enum class BacklogMethod {
+    Refuel = 1,
+    Intake = 2
+};
+
 // System states for Mealy machine
 enum class SystemState {
     Waiting,

--- a/src/backlog_storage.cpp
+++ b/src/backlog_storage.cpp
@@ -1,0 +1,124 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of fuelflux application
+
+#include "backlog_storage.h"
+
+#include <sqlite3.h>
+
+namespace fuelflux {
+
+namespace {
+constexpr const char* kCreateTableSql =
+    "CREATE TABLE IF NOT EXISTS backlog ("
+    "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+    "uid TEXT NOT NULL,"
+    "method INTEGER NOT NULL,"
+    "data TEXT NOT NULL"
+    ");";
+} // namespace
+
+BacklogStorage::BacklogStorage(const std::string& path) : db_(nullptr) {
+    if (sqlite3_open(path.c_str(), &db_) != SQLITE_OK) {
+        db_ = nullptr;
+        return;
+    }
+    (void)Execute(kCreateTableSql);
+}
+
+BacklogStorage::~BacklogStorage() {
+    Close();
+}
+
+bool BacklogStorage::IsOpen() const {
+    return db_ != nullptr;
+}
+
+bool BacklogStorage::AddItem(const std::string& uid, BacklogMethod method, const std::string& data) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!db_) {
+        return false;
+    }
+
+    sqlite3_stmt* stmt = nullptr;
+    const char* sql = "INSERT INTO backlog (uid, method, data) VALUES (?, ?, ?);";
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        return false;
+    }
+
+    sqlite3_bind_text(stmt, 1, uid.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_int(stmt, 2, static_cast<int>(method));
+    sqlite3_bind_text(stmt, 3, data.c_str(), -1, SQLITE_TRANSIENT);
+
+    const bool success = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    return success;
+}
+
+std::vector<BacklogItem> BacklogStorage::LoadAll() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<BacklogItem> items;
+    if (!db_) {
+        return items;
+    }
+
+    sqlite3_stmt* stmt = nullptr;
+    const char* sql = "SELECT id, uid, method, data FROM backlog ORDER BY id ASC;";
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        return items;
+    }
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        BacklogItem item;
+        item.id = sqlite3_column_int(stmt, 0);
+        const unsigned char* uid = sqlite3_column_text(stmt, 1);
+        const unsigned char* data = sqlite3_column_text(stmt, 3);
+        item.uid = uid ? reinterpret_cast<const char*>(uid) : "";
+        item.method = static_cast<BacklogMethod>(sqlite3_column_int(stmt, 2));
+        item.data = data ? reinterpret_cast<const char*>(data) : "";
+        items.push_back(std::move(item));
+    }
+
+    sqlite3_finalize(stmt);
+    return items;
+}
+
+bool BacklogStorage::RemoveItem(int id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!db_) {
+        return false;
+    }
+
+    sqlite3_stmt* stmt = nullptr;
+    const char* sql = "DELETE FROM backlog WHERE id = ?;";
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        return false;
+    }
+
+    sqlite3_bind_int(stmt, 1, id);
+    const bool success = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    return success;
+}
+
+bool BacklogStorage::Execute(const std::string& sql) {
+    if (!db_) {
+        return false;
+    }
+    char* errorMessage = nullptr;
+    const int rc = sqlite3_exec(db_, sql.c_str(), nullptr, nullptr, &errorMessage);
+    if (errorMessage) {
+        sqlite3_free(errorMessage);
+    }
+    return rc == SQLITE_OK;
+}
+
+void BacklogStorage::Close() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (db_) {
+        sqlite3_close(db_);
+        db_ = nullptr;
+    }
+}
+
+} // namespace fuelflux

--- a/src/backlog_worker.cpp
+++ b/src/backlog_worker.cpp
@@ -1,0 +1,82 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of fuelflux application
+
+#include "backlog_worker.h"
+
+namespace fuelflux {
+
+BacklogWorker::BacklogWorker(std::shared_ptr<BacklogStorage> storage,
+                             std::unique_ptr<IBackend> backend,
+                             std::chrono::milliseconds interval)
+    : storage_(std::move(storage))
+    , backend_(std::move(backend))
+    , interval_(interval)
+    , running_(false) {}
+
+BacklogWorker::~BacklogWorker() {
+    Stop();
+}
+
+void BacklogWorker::Start() {
+    if (running_.exchange(true)) {
+        return;
+    }
+    workerThread_ = std::thread([this]() { RunLoop(); });
+}
+
+void BacklogWorker::Stop() {
+    if (!running_.exchange(false)) {
+        return;
+    }
+    cv_.notify_all();
+    if (workerThread_.joinable()) {
+        workerThread_.join();
+    }
+}
+
+bool BacklogWorker::IsRunning() const {
+    return running_.load();
+}
+
+bool BacklogWorker::ProcessOnce() {
+    if (!storage_ || !backend_) {
+        return false;
+    }
+    const auto items = storage_->LoadAll();
+    for (const auto& item : items) {
+        if (!ProcessItem(item)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void BacklogWorker::RunLoop() {
+    while (running_.load()) {
+        (void)ProcessOnce();
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait_for(lock, interval_, [this]() { return !running_.load(); });
+    }
+}
+
+bool BacklogWorker::ProcessItem(const BacklogItem& item) {
+    if (!backend_->Authorize(item.uid)) {
+        return false;
+    }
+
+    bool sent = false;
+    if (item.method == BacklogMethod::Refuel) {
+        sent = backend_->RefuelFromPayload(item.data);
+    } else if (item.method == BacklogMethod::Intake) {
+        sent = backend_->IntakeFromPayload(item.data);
+    }
+
+    const bool deauthorized = backend_->Deauthorize();
+    if (sent && deauthorized) {
+        return storage_->RemoveItem(item.id);
+    }
+    return false;
+}
+
+} // namespace fuelflux

--- a/tests/backlog_test.cpp
+++ b/tests/backlog_test.cpp
@@ -1,0 +1,152 @@
+// Copyright (C) 2025 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of fuelflux application
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <string>
+
+#include "backlog_storage.h"
+#include "backlog_worker.h"
+
+using namespace fuelflux;
+
+namespace {
+
+class FakeBackend : public IBackend {
+public:
+    bool Authorize(const std::string& uid) override {
+        calls.push_back("authorize");
+        lastAuthorizedUid = uid;
+        authorized = authorizeResult;
+        return authorizeResult;
+    }
+
+    bool Deauthorize() override {
+        calls.push_back("deauthorize");
+        authorized = false;
+        return deauthorizeResult;
+    }
+
+    bool Refuel(TankNumber, Volume) override { return true; }
+    bool Intake(TankNumber, Volume, IntakeDirection) override { return true; }
+
+    bool RefuelFromPayload(const std::string& payload) override {
+        calls.push_back("refuel");
+        lastPayload = payload;
+        return refuelResult;
+    }
+
+    bool IntakeFromPayload(const std::string& payload) override {
+        calls.push_back("intake");
+        lastPayload = payload;
+        return intakeResult;
+    }
+
+    bool IsAuthorized() const override { return authorized; }
+    const std::string& GetToken() const override { return token; }
+    int GetRoleId() const override { return 0; }
+    double GetAllowance() const override { return 0.0; }
+    double GetPrice() const override { return 0.0; }
+    const std::vector<BackendTankInfo>& GetFuelTanks() const override { return tanks; }
+    const std::string& GetLastError() const override { return lastError; }
+    bool WasLastErrorNetwork() const override { return false; }
+    const std::string& GetLastRequestPayload() const override { return lastPayload; }
+
+    bool authorizeResult = true;
+    bool deauthorizeResult = true;
+    bool refuelResult = true;
+    bool intakeResult = true;
+    bool authorized = false;
+    std::string lastAuthorizedUid;
+    std::string lastPayload;
+    std::string token;
+    std::string lastError;
+    std::vector<BackendTankInfo> tanks;
+    std::vector<std::string> calls;
+};
+
+std::string MakeTempDbPath(const std::string& name) {
+    const auto base = std::filesystem::temp_directory_path();
+    return (base / name).string();
+}
+
+} // namespace
+
+TEST(BacklogStorageTest, PersistsItemsAcrossRestarts) {
+    const std::string path = MakeTempDbPath("fuelflux_backlog_test.db");
+    std::filesystem::remove(path);
+
+    {
+        BacklogStorage storage(path);
+        ASSERT_TRUE(storage.IsOpen());
+        EXPECT_TRUE(storage.AddItem("uid-1", BacklogMethod::Refuel, "payload-1"));
+        EXPECT_TRUE(storage.AddItem("uid-2", BacklogMethod::Intake, "payload-2"));
+    }
+
+    BacklogStorage storage(path);
+    ASSERT_TRUE(storage.IsOpen());
+    auto items = storage.LoadAll();
+    ASSERT_EQ(items.size(), 2u);
+    EXPECT_EQ(items[0].uid, "uid-1");
+    EXPECT_EQ(items[0].method, BacklogMethod::Refuel);
+    EXPECT_EQ(items[0].data, "payload-1");
+
+    EXPECT_TRUE(storage.RemoveItem(items[0].id));
+    auto remaining = storage.LoadAll();
+    ASSERT_EQ(remaining.size(), 1u);
+    EXPECT_EQ(remaining[0].uid, "uid-2");
+
+    std::filesystem::remove(path);
+}
+
+TEST(BacklogWorkerTest, ProcessesAndRemovesItem) {
+    const std::string path = MakeTempDbPath("fuelflux_backlog_worker.db");
+    std::filesystem::remove(path);
+
+    auto storage = std::make_shared<BacklogStorage>(path);
+    ASSERT_TRUE(storage->IsOpen());
+    ASSERT_TRUE(storage->AddItem("uid-123", BacklogMethod::Refuel, "payload-123"));
+
+    auto backend = std::make_unique<FakeBackend>();
+    auto backendPtr = backend.get();
+    BacklogWorker worker(storage, std::move(backend), std::chrono::milliseconds(10));
+
+    EXPECT_TRUE(worker.ProcessOnce());
+    auto items = storage->LoadAll();
+    EXPECT_TRUE(items.empty());
+    EXPECT_EQ(backendPtr->lastAuthorizedUid, "uid-123");
+    EXPECT_EQ(backendPtr->lastPayload, "payload-123");
+    ASSERT_EQ(backendPtr->calls.size(), 3u);
+    EXPECT_EQ(backendPtr->calls[0], "authorize");
+    EXPECT_EQ(backendPtr->calls[1], "refuel");
+    EXPECT_EQ(backendPtr->calls[2], "deauthorize");
+
+    std::filesystem::remove(path);
+}
+
+TEST(BacklogWorkerTest, KeepsItemOnFailure) {
+    const std::string path = MakeTempDbPath("fuelflux_backlog_worker_fail.db");
+    std::filesystem::remove(path);
+
+    auto storage = std::make_shared<BacklogStorage>(path);
+    ASSERT_TRUE(storage->IsOpen());
+    ASSERT_TRUE(storage->AddItem("uid-456", BacklogMethod::Intake, "payload-456"));
+
+    auto backend = std::make_unique<FakeBackend>();
+    auto backendPtr = backend.get();
+    backendPtr->intakeResult = false;
+    BacklogWorker worker(storage, std::move(backend), std::chrono::milliseconds(10));
+
+    EXPECT_FALSE(worker.ProcessOnce());
+    auto items = storage->LoadAll();
+    ASSERT_EQ(items.size(), 1u);
+    EXPECT_EQ(items[0].uid, "uid-456");
+    ASSERT_EQ(backendPtr->calls.size(), 3u);
+    EXPECT_EQ(backendPtr->calls[0], "authorize");
+    EXPECT_EQ(backendPtr->calls[1], "intake");
+    EXPECT_EQ(backendPtr->calls[2], "deauthorize");
+
+    std::filesystem::remove(path);
+}


### PR DESCRIPTION
### Motivation
- Provide persistent storage for failed backend messages so they survive restarts and can be retried later. 
- Add a background worker that retries persisted refuel/intake requests and preserves original payloads (including timestamps). 
- Ensure backend sends are serialized to support parallel backend instances while avoiding concurrent requests. 

### Description
- Added a SQLite-backed storage API `BacklogStorage` with a single `backlog` table (fields: `id`, `uid`, `method`, `data`) and implemented it in `include/backlog_storage.h` / `src/backlog_storage.cpp`.
- Implemented `BacklogWorker` in `include/backlog_worker.h` / `src/backlog_worker.cpp` that runs a background thread (or can be exercised with `ProcessOnce`) to: `Authorize(uid)`, send saved payload via payload-based helpers, then `Deauthorize()` and remove the item on success.
- Extended backend interface and implementation with payload-based methods and network-tracking: added `RefuelFromPayload`, `IntakeFromPayload`, `HttpRequestWrapperRaw`, `WasLastErrorNetwork`, `GetLastRequestPayload`, and a `sendMutex_` to serialize all HTTP sends in `include/backend.h` / `src/backend.cpp`.
- Controller changes: constructor gains backlog-enable flag and DB path, controller creates/starts `BacklogStorage` and `BacklogWorker` on initialization, stops worker on shutdown, and on network failures enqueues the last-request payload into backlog from `logRefuelTransaction` and `logIntakeTransaction` (so original JSON including `TimeAt` is preserved).
- Build & tests: CMake updated to require SQLite3 and include new sources/headers; tests updated and new tests added in `tests/backlog_test.cpp` to validate persistence and worker behavior; backend tests extended to cover payload helpers and network flag.

### Testing
- Configured and built with tests enabled: `cmake -S . -B build -DENABLE_TESTING=ON -DTARGET_REAL_CARD_READER=OFF -DTARGET_REAL_DISPLAY=OFF` and `cmake --build build` (build succeeded).
- Ran the test suite: `ctest --test-dir build` and all tests passed (73/73 tests passed, 0 failed).
- New unit tests: `tests/backlog_test.cpp` (BacklogStorage persistence; BacklogWorker processing/removal and failure behavior) were added and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e3e9f27208321b47de340f55d494a)