### PR TITLE
Fix pump header namespace for TARGET_REAL_PUMP build

### DIFF
--- a/include/peripherals/pump.h
+++ b/include/peripherals/pump.h
@@ -4,11 +4,12 @@
 #include <memory>
 #include <string>
 
-namespace fuelflux::peripherals {
-
 #ifdef TARGET_REAL_PUMP
 class GpioLine;
+#endif
 
+namespace fuelflux::peripherals {
+#ifdef TARGET_REAL_PUMP
 namespace pump_defaults {
     constexpr const char* GPIO_CHIP = "/dev/gpiochip0";
     constexpr int RELAY_PIN = 259;


### PR DESCRIPTION
### Motivation
- Enabling `TARGET_REAL_PUMP` failed the build due to an incomplete type: the `GpioLine` forward declaration was in `fuelflux::peripherals` while the actual `GpioLine` class is defined in the global namespace, causing a mismatch when `std::unique_ptr<GpioLine>` and calls like `relayLine_->set(...)` were instantiated.

### Description
- Move the `GpioLine` forward declaration to the global scope and keep `pump_defaults` and `HardwarePump` inside `fuelflux::peripherals` by updating `include/peripherals/pump.h` so the forward declaration matches the real `GpioLine` definition.

### Testing
- Ran `cmake -S . -B build -DTARGET_REAL_PUMP=ON`, then `cmake --build build`, and `ctest --test-dir build`; configuration and build completed successfully and `ctest` reported no tests were found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982238b8408832195433a73f8199028)