### PR TITLE
Enable PPP interface binding via USE_IF2IP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 if(TARGET_SIM800C)
     message(STATUS "TARGET_SIM800C enabled: HTTP backend will bind to ppp0")
-    add_compile_definitions(TARGET_SIM800C)
+    add_compile_definitions(TARGET_SIM800C USE_IF2IP)
 endif()
 
 if(TARGET_REAL_DISPLAY)


### PR DESCRIPTION
### Motivation
- Ensure the HTTP client actually binds to the `ppp0` interface on SIM800C targets because cpp-httplib requires `USE_IF2IP` to enable interface-to-IP binding, otherwise connection attempts can fail with "Ошибка связи с сервером".

### Description
- Add the `USE_IF2IP` compile definition alongside `TARGET_SIM800C` in `CMakeLists.txt` so cpp-httplib will perform interface->IP binding when `TARGET_SIM800C` is enabled.

### Testing
- Ran `cmake -S . -B build -DENABLE_TESTING=ON`, `cmake --build build`, and `ctest --test-dir build`, and all automated tests passed (`80/80`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c9491b2c8321b4920f5a9a83e183)