### PR TITLE
Refactor StateMachine error recovery to use posted follow-on event

### DIFF
--- a/include/state_machine.h
+++ b/include/state_machine.h
@@ -12,7 +12,6 @@
 #include <atomic>
 #include <mutex>
 #include <string>
-#include <optional>
 
 namespace fuelflux {
 
@@ -82,13 +81,6 @@ private:
 
     // Transition table: (current_state, event) -> (next_state, action)
     std::unordered_map<std::pair<SystemState, Event>, std::pair<SystemState, std::function<void()>>> transitions_;
-
-    // Override target state for conditional transitions.
-    // When set by a transition action (under mutex_), processEvent will use this 
-    // instead of the transition table's target state.
-    // MUST be accessed only while holding mutex_ to prevent race conditions.
-    // Reset before each action executes and consumed after action completes.
-    std::optional<SystemState> overrideTargetState_;
 
     // Concurrency
     mutable std::recursive_mutex mutex_;

--- a/include/types.h
+++ b/include/types.h
@@ -70,6 +70,7 @@ enum class Event {
     IntakeComplete,
     CancelPressed,
     Timeout,
+    ErrorRecovery,
     Error
 };
 


### PR DESCRIPTION
### Motivation

- Simplify and harden error-state recovery by removing the mutable in-process `overrideTargetState_` mechanism which made `processEvent()` behavior conditional after action execution.
- Use the controller's event queue to schedule follow-on state changes so recovery logic runs via the normal event-processing path and reduces race / locking complexity.

### Description

- Removed `overrideTargetState_` and the `#include <optional>` usage from `StateMachine`, and simplified `processEvent()` to always apply the transition-table target state directly.
- Added new event `Event::ErrorRecovery` in `include/types.h` and wired a transition `Error + ErrorRecovery -> Waiting` in the transition table.
- Replaced direct state-override in `onErrorCancelPressed()` with a call to `controller_->postEvent(Event::ErrorRecovery)` after a successful `controller_->reinitializeDevice()` so the follow-on state change is handled asynchronously via the controller event queue.

### Testing

- Configured and built tests with `cmake -S . -B build -DENABLE_TESTING=ON -DTARGET_REAL_KEYBOARD=OFF -DTARGET_REAL_CARD_READER=OFF -DTARGET_REAL_PUMP=OFF -DTARGET_REAL_DISPLAY=OFF -DTARGET_SIM800C=OFF` and built with `cmake --build build -j4` successfully.
- Ran the full test suite with `ctest --test-dir build --output-on-failure --timeout 60` and all tests passed (`88/88` passing).
- Searched for repo linter configs with `rg` and found no linter configuration files to run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4e7245a8832181011def239ba79f)