### PR TITLE
Add NotAuthorized state for failed authorization and update state machine & tests

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -39,6 +39,7 @@ enum class SystemState {
     Waiting,
     PinEntry,
     Authorization,
+    NotAuthorized,
     TankSelection,
     VolumeEntry,
     Refueling,

--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -194,7 +194,7 @@ void StateMachine::setupTransitions() {
     transitions_[{SystemState::Authorization, Event::PinEntryStarted}]     = {SystemState::Authorization,     noOp};
     transitions_[{SystemState::Authorization, Event::PinEntered}]          = {SystemState::Authorization,     noOp};
     transitions_[{SystemState::Authorization, Event::AuthorizationSuccess}]= {SystemState::TankSelection,     noOp};
-    transitions_[{SystemState::Authorization, Event::AuthorizationFailed}] = {SystemState::Error,             noOp};
+    transitions_[{SystemState::Authorization, Event::AuthorizationFailed}] = {SystemState::NotAuthorized,     noOp};
     transitions_[{SystemState::Authorization, Event::TankSelected}]        = {SystemState::Authorization,     noOp};
     transitions_[{SystemState::Authorization, Event::VolumeEntered}]       = {SystemState::Authorization,     noOp};
     transitions_[{SystemState::Authorization, Event::AmountEntered}]       = {SystemState::Authorization,     noOp};
@@ -208,6 +208,26 @@ void StateMachine::setupTransitions() {
     transitions_[{SystemState::Authorization, Event::CancelPressed}]       = {SystemState::Authorization,     noOp};
     transitions_[{SystemState::Authorization, Event::Timeout}]             = {SystemState::Authorization,     noOp};
     transitions_[{SystemState::Authorization, Event::Error}]               = {SystemState::Error,             noOp};
+
+    // From NotAuthorized state
+    transitions_[{SystemState::NotAuthorized, Event::CardPresented}]       = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::PinEntryStarted}]     = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::PinEntered}]          = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::AuthorizationSuccess}]= {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::AuthorizationFailed}] = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::TankSelected}]        = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::VolumeEntered}]       = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::AmountEntered}]       = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::RefuelingStarted}]    = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::RefuelingStopped}]    = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::DataTransmissionComplete}] = {SystemState::NotAuthorized, noOp};
+    transitions_[{SystemState::NotAuthorized, Event::IntakeSelected}]      = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::IntakeDirectionSelected}] = {SystemState::NotAuthorized, noOp};
+    transitions_[{SystemState::NotAuthorized, Event::IntakeVolumeEntered}] = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::IntakeComplete}]      = {SystemState::NotAuthorized,     noOp};
+    transitions_[{SystemState::NotAuthorized, Event::CancelPressed}]       = {SystemState::Waiting,           [this]() { onCancelPressed();        }};
+    transitions_[{SystemState::NotAuthorized, Event::Timeout}]             = {SystemState::Waiting,           [this]() { onTimeout();              }};
+    transitions_[{SystemState::NotAuthorized, Event::Error}]               = {SystemState::Error,             noOp};
 
     // From TankSelection state
     transitions_[{SystemState::TankSelection, Event::CardPresented}]       = {SystemState::TankSelection,     noOp};
@@ -491,6 +511,13 @@ DisplayMessage StateMachine::getDisplayMessage() const {
             message.line2 = "Пожалуйста, подождите";
             message.line3 = "";
             message.line4 = controller_->getDeviceSerialNumber();
+            break;
+
+        case SystemState::NotAuthorized:
+            message.line1 = "Доступ запрещен";
+            message.line2 = "Неверная карта или PIN";
+            message.line3 = "Нажмите Отмена (B)";
+            message.line4 = "или подождите";
             break;
 
         case SystemState::TankSelection:


### PR DESCRIPTION
### Motivation
- Failed authorization should not be treated as a generic `Error` but as an expected `NotAuthorized` outcome with a clear user-facing state. 
- Ensure the Mealy state machine remains total: every event must be handled in every state (including the new `NotAuthorized`).

### Description
- Added a new `SystemState::NotAuthorized` enum value in `include/types.h`.
- Changed the `Authorization + AuthorizationFailed` transition to go to `NotAuthorized` instead of `Error` and added a full transition set for `NotAuthorized` in `src/state_machine.cpp` so all events are covered and `CancelPressed`/`Timeout` return to `Waiting`.
- Added display text for `NotAuthorized` in `StateMachine::getDisplayMessage()` so the UI shows a specific message for authorization failures.
- Added controller tests in `tests/controller_test.cpp` to verify: transition to `NotAuthorized`, return to `Waiting` via Cancel and Timeout, and that the `NotAuthorized` state processes all events (totality check).

### Testing
- Built the project with `cmake -S . -B build -DENABLE_TESTING=ON` and `cmake --build build -j$(nproc)` successfully; library and tests built.
- Ran a focused controller test set with `ctest -R` for the new tests and related controller tests and all targeted tests passed.
- Performed a coverage-oriented build (`-DCMAKE_BUILD_TYPE=Debug` with `--coverage`) and executed the new controller tests; `gcov` reports function/line execution for `src/state_machine.cpp` at/near 100% for the exercised functions, meeting the 95% target for the modified functionality.
- Note: a full `ctest --test-dir build --output-on-failure` run progressed through most suites but stalled on an unrelated existing `BoundedExecutorTest.RejectsTasksAfterShutdown` in this environment; the modified state-machine behavior was validated with focused test execution above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4e4f689c8321ae57b80c0c684682)