### PR TITLE
feat: support new tank dto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This file is a part of fuelflux application
 
 cmake_minimum_required(VERSION 3.16)
-project(FuelFlux VERSION 0.1.2 LANGUAGES CXX)
+project(FuelFlux VERSION 0.2.0 LANGUAGES CXX)
 
 # Generate version header from template
 configure_file(

--- a/include/backend.h
+++ b/include/backend.h
@@ -21,9 +21,13 @@ class MessageStorage;
 
 // Tank information structure for backend
 struct BackendTankInfo {
-    int idTank;
+    int idTank = 0;                 // Backend tank identifier used in API reports
+    int visualNumberTank = 0;       // Tank number shown to users in UI
     std::string nameTank = "";
-    Volume volume = 0.0;  // Tank capacity in liters
+    Volume volume = 0.0;            // Effective maximum permitted volume for this tank (liters);
+                                     // controller-side validation treats this as the upper bound for
+                                     // entered volume. This may represent the physical tank capacity
+                                     // or a backend-configured per-tank limit, depending on backend semantics.
 };
 
 // User card structure for cache population
@@ -112,6 +116,10 @@ protected:
     // Get the bounded executor for async deauthorization requests
     // Uses Meyer's singleton pattern for thread-safe lazy initialization
     static BoundedExecutor& GetDeauthorizeExecutor();
+
+    // Map TankNumber in a payload from visualNumberTank to idTank.
+    // Returns true if a match was found and the mapping was applied.
+    bool ApplyVisualTankMapping(nlohmann::json& requestBody) const;
 
     std::string controllerUid_;
     std::string authorizedUid_;

--- a/include/config.h
+++ b/include/config.h
@@ -6,7 +6,8 @@
 
 #include <string>
 
-const std::string CONTROLLER_UID = "232390330480218";  
+// const std::string CONTROLLER_UID = "232390330480218";
+const std::string CONTROLLER_UID = "1"; 
 const std::string BACKEND_API_URL = "http://ttft.uxp.ru";
 
 #ifdef FUELFLUX_UNIX_FOLDER_CONVENTION

--- a/include/config.h
+++ b/include/config.h
@@ -10,6 +10,10 @@
 const std::string CONTROLLER_UID = "1"; 
 const std::string BACKEND_API_URL = "http://ttft.uxp.ru";
 
+// Safety cap on keyboard input length. In normal operation, inputs are much shorter;
+// this limit guards against chained or abnormal conditions that could grow the buffer indefinitely.
+constexpr std::size_t INPUT_MAX_LENGTH = 1024;
+
 #ifdef FUELFLUX_UNIX_FOLDER_CONVENTION
 const std::string STORAGE_DB_PATH = "/var/fuelflux/db/fuelflux_storage.db";
 const std::string CACHE_DB_PATH = "/var/fuelflux/db/fuelflux_cache.db";

--- a/src/backend_base.cpp
+++ b/src/backend_base.cpp
@@ -94,8 +94,33 @@ bool BackendBase::Authorize(const std::string& uid) {
             for (const auto& tank : response["fuelTanks"]) {
                 BackendTankInfo tankInfo;
                 tankInfo.idTank = tank.value("idTank", 0);
+                tankInfo.visualNumberTank = tank.value("visualNumberTank", 0);
                 tankInfo.nameTank = tank.value("nameTank", "");
-                tankInfo.volume = tank.value("volume", 0.0);
+
+                bool checkEnoughFuel = false;
+                if (tank.contains("isCheckEnoughFuel") && !tank["isCheckEnoughFuel"].is_null()) {
+                    const auto& isCheckEnoughFuel = tank["isCheckEnoughFuel"];
+                    if (isCheckEnoughFuel.is_boolean()) {
+                        checkEnoughFuel = isCheckEnoughFuel.get<bool>();
+                    } else if (isCheckEnoughFuel.is_number_integer()) {
+                        checkEnoughFuel = isCheckEnoughFuel.get<int>() != 0;
+                    }
+                }
+                if (checkEnoughFuel && tank.contains("allowanceTank") && !tank["allowanceTank"].is_null()) {
+                    const auto& allowanceTank = tank["allowanceTank"];
+                    if (allowanceTank.is_string()) {
+                        try {
+                            tankInfo.volume = std::stod(allowanceTank.get<std::string>());
+                        } catch (const std::exception& e) {
+                            tankInfo.volume = 0.0;
+                            LOG_BCK_WARN("Failed to parse allowanceTank '{}' as number (defaulting to 0): {}",
+                                         allowanceTank.get<std::string>(), e.what());
+                        }
+                    } else if (allowanceTank.is_number()) {
+                        tankInfo.volume = allowanceTank.get<double>();
+                    }
+                }
+
                 fuelTanks.push_back(tankInfo);
             }
         }
@@ -207,7 +232,7 @@ bool BackendBase::Refuel(TankNumber tankNumber, Volume volume) {
         const auto tankIt = std::find_if(
             fuelTanks_.begin(),
             fuelTanks_.end(),
-            [tankNumber](const BackendTankInfo& tank) { return tank.idTank == tankNumber; });
+            [tankNumber](const BackendTankInfo& tank) { return tank.visualNumberTank == tankNumber; });
         if (tankIt == fuelTanks_.end()) {
             LOG_BCK_ERROR("Invalid refueling report: tank {} not found in authorized tanks", tankNumber);
             lastError_ = StdControllerError;
@@ -232,7 +257,7 @@ bool BackendBase::Refuel(TankNumber tankNumber, Volume volume) {
                                      .count();
 
         nlohmann::json requestBody;
-        requestBody["TankNumber"] = tankNumber;
+        requestBody["TankNumber"] = tankIt->idTank;
         requestBody["FuelVolume"] = volume;
         requestBody["TimeAt"] = timestampMs;
 
@@ -287,7 +312,7 @@ bool BackendBase::Intake(TankNumber tankNumber, Volume volume, IntakeDirection d
         const auto tankIt = std::find_if(
             fuelTanks_.begin(),
             fuelTanks_.end(),
-            [tankNumber](const BackendTankInfo& tank) { return tank.idTank == tankNumber; });
+            [tankNumber](const BackendTankInfo& tank) { return tank.visualNumberTank == tankNumber; });
         if (tankIt == fuelTanks_.end()) {
             LOG_BCK_ERROR("Invalid intake report: tank {} not found in authorized tanks", tankNumber);
             lastError_ = StdControllerError;
@@ -312,7 +337,7 @@ bool BackendBase::Intake(TankNumber tankNumber, Volume volume, IntakeDirection d
                                      .count();
 
         nlohmann::json requestBody;
-        requestBody["TankNumber"] = tankNumber;
+        requestBody["TankNumber"] = tankIt->idTank;
         requestBody["IntakeVolume"] = volume;
         requestBody["Direction"] = static_cast<int>(direction);
         requestBody["TimeAt"] = timestampMs;
@@ -351,6 +376,24 @@ bool BackendBase::Intake(TankNumber tankNumber, Volume volume, IntakeDirection d
     }
 }
 
+bool BackendBase::ApplyVisualTankMapping(nlohmann::json& requestBody) const {
+    if (!requestBody.contains("TankNumber") || !requestBody["TankNumber"].is_number_integer()) {
+        return false;
+    }
+    const int visualNumber = requestBody["TankNumber"].get<int>();
+    const auto tankIt = std::find_if(
+        fuelTanks_.begin(),
+        fuelTanks_.end(),
+        [visualNumber](const BackendTankInfo& tank) { return tank.visualNumberTank == visualNumber; });
+    if (tankIt == fuelTanks_.end()) {
+        LOG_BCK_WARN("Tank with visualNumber {} not found in authorized tanks; sending payload without id mapping",
+                     visualNumber);
+        return false;
+    }
+    requestBody["TankNumber"] = tankIt->idTank;
+    return true;
+}
+
 bool BackendBase::RefuelPayload(const std::string& payload) {
     try {
         if (!session_.IsAuthorized()) {
@@ -359,12 +402,14 @@ bool BackendBase::RefuelPayload(const std::string& payload) {
             return false;
         }
 
-        const auto requestBody = nlohmann::json::parse(payload, nullptr, false);
+        auto requestBody = nlohmann::json::parse(payload, nullptr, false);
         if (requestBody.is_discarded()) {
             LOG_BCK_ERROR("Invalid refueling payload");
             lastError_ = StdControllerError;
             return false;
         }
+
+        ApplyVisualTankMapping(requestBody);
 
         nlohmann::json response = HttpRequestWrapper("/api/pump/refuel", "POST", requestBody, true);
         std::string responseError;
@@ -393,12 +438,14 @@ bool BackendBase::IntakePayload(const std::string& payload) {
             return false;
         }
 
-        const auto requestBody = nlohmann::json::parse(payload, nullptr, false);
+        auto requestBody = nlohmann::json::parse(payload, nullptr, false);
         if (requestBody.is_discarded()) {
             LOG_BCK_ERROR("Invalid intake payload");
             lastError_ = StdControllerError;
             return false;
         }
+
+        ApplyVisualTankMapping(requestBody);
 
         nlohmann::json response = HttpRequestWrapper("/api/pump/fuel-intake", "POST", requestBody, true);
         std::string responseError;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -460,7 +460,9 @@ void Controller::clearInputSilent() {
 }
 
 void Controller::addDigitToInput(char digit) {
-    if (currentInput_.length() < 10) { // Limit input length
+    // In reality we do not limit input length
+    // This is unreasomably large number t protect against abnormal conditions
+    if (currentInput_.length() < 1024) { 
         currentInput_ += digit;
         postEvent(Event::InputUpdated);
     }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -460,9 +460,9 @@ void Controller::clearInputSilent() {
 }
 
 void Controller::addDigitToInput(char digit) {
-    // In reality we do not limit input length
-    // This is unreasomably large number t protect against abnormal conditions
-    if (currentInput_.length() < 1024) { 
+    // Normal inputs are far shorter than INPUT_MAX_LENGTH; this cap protects
+    // against abnormal or chained conditions that could grow the buffer indefinitely.
+    if (currentInput_.length() < INPUT_MAX_LENGTH) { 
         currentInput_ += digit;
         postEvent(Event::InputUpdated);
     }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -499,7 +499,7 @@ void Controller::requestAuthorization(const UserId& userId) {
         availableTanks_.clear();
         for (const auto& tank : backend_->GetFuelTanks()) {
             TankInfo info;
-            info.number = tank.idTank;
+            info.number = tank.visualNumberTank;
             availableTanks_.push_back(info);
         }
         
@@ -572,7 +572,7 @@ Volume Controller::getTankVolume(TankNumber tankNumber) const {
     if (backend_) {
         const auto& tanks = backend_->GetFuelTanks();
         for (const auto& tank : tanks) {
-            if (tank.idTank == tankNumber) {
+            if (tank.visualNumberTank == tankNumber) {
                 return tank.volume;
             }
         }

--- a/tests/backend_bounded_test.cpp
+++ b/tests/backend_bounded_test.cpp
@@ -30,7 +30,7 @@ TEST(BackendIntegrationTest, RapidDeauthorizationBounded) {
             {"Allowance", 100.0},
             {"Price", 50.0},
             {"fuelTanks", nlohmann::json::array({
-                {{"idTank", 1}, {"nameTank", "Tank 1"}}
+                {{"idTank", 1}, {"visualNumberTank", 1}, {"nameTank", "Tank 1"}, {"isCheckEnoughFuel", 1}, {"allowanceTank", "120.0"}}
             })}
         };
         res.set_content(response.dump(), "application/json");

--- a/tests/backend_test.cpp
+++ b/tests/backend_test.cpp
@@ -109,8 +109,8 @@ protected:
             response["Allowance"] = 50.0;
             response["Price"] = 45.5;
             response["fuelTanks"] = nlohmann::json::array();
-            response["fuelTanks"].push_back({{"idTank", 1}, {"nameTank", "АИ-95"}});
-            response["fuelTanks"].push_back({{"idTank", 2}, {"nameTank", "ДТ"}});
+            response["fuelTanks"].push_back({{"idTank", 1}, {"visualNumberTank", 1}, {"nameTank", "АИ-95"}, {"isCheckEnoughFuel", 1}, {"allowanceTank", "100.0"}});
+            response["fuelTanks"].push_back({{"idTank", 2}, {"visualNumberTank", 2}, {"nameTank", "ДТ"}, {"isCheckEnoughFuel", 0}, {"allowanceTank", "999.0"}});
             
             res.status = 200;
             res.set_content(response.dump(), "application/json");
@@ -179,9 +179,13 @@ TEST_F(BackendTest, AuthorizeSuccess) {
     EXPECT_EQ(backend.GetPrice(), 45.5);
     EXPECT_EQ(backend.GetFuelTanks().size(), 2);
     EXPECT_EQ(backend.GetFuelTanks()[0].idTank, 1);
+    EXPECT_EQ(backend.GetFuelTanks()[0].visualNumberTank, 1);
     EXPECT_EQ(backend.GetFuelTanks()[0].nameTank, "АИ-95");
+    EXPECT_DOUBLE_EQ(backend.GetFuelTanks()[0].volume, 100.0);
     EXPECT_EQ(backend.GetFuelTanks()[1].idTank, 2);
+    EXPECT_EQ(backend.GetFuelTanks()[1].visualNumberTank, 2);
     EXPECT_EQ(backend.GetFuelTanks()[1].nameTank, "ДТ");
+    EXPECT_DOUBLE_EQ(backend.GetFuelTanks()[1].volume, 0.0);
 }
 
 // Test failed authorization
@@ -251,6 +255,40 @@ TEST_F(BackendTest, RefuelSuccess) {
     EXPECT_EQ(backend.GetAllowance(), 25.0);  // 50.0 - 25.0
 }
 
+// Test that UI-selected visual number is mapped to backend id in refuel report
+TEST_F(BackendTest, RefuelUsesTankIdMappedFromVisualNumber) {
+    mockServer->handleAuthorize = [](const httplib::Request& req [[maybe_unused]], httplib::Response& res) {
+        nlohmann::json response;
+        response["Token"] = "test-token-12345";
+        response["RoleId"] = 1;
+        response["Allowance"] = 200.0;
+        response["Price"] = 45.5;
+        response["fuelTanks"] = nlohmann::json::array();
+        response["fuelTanks"].push_back(
+            {{"idTank", 44},
+             {"visualNumberTank", 7},
+             {"nameTank", "АИ-95"},
+             {"isCheckEnoughFuel", 1},
+             {"allowanceTank", "150.0"}});
+
+        res.status = 200;
+        res.set_content(response.dump(), "application/json");
+    };
+
+    mockServer->handleRefuel = [](const httplib::Request& req, httplib::Response& res) {
+        const auto body = nlohmann::json::parse(req.body);
+        EXPECT_EQ(body.value("TankNumber", -1), 44);
+        EXPECT_DOUBLE_EQ(body.value("FuelVolume", -1.0), 25.0);
+
+        res.status = 200;
+        res.set_content("null", "application/json");
+    };
+
+    Backend backend(baseAPI, controllerUid);
+    EXPECT_TRUE(backend.Authorize("card-uid-12345"));
+    EXPECT_TRUE(backend.Refuel(7, 25.0));
+}
+
 // Test refuel without authorization
 TEST_F(BackendTest, RefuelWithoutAuthorization) {
     Backend backend(baseAPI, controllerUid);
@@ -304,7 +342,7 @@ TEST_F(BackendTest, IntakeSuccess) {
         response["Allowance"] = nlohmann::json();  // null
         response["Price"] = nlohmann::json();  // null
         response["fuelTanks"] = nlohmann::json::array();
-        response["fuelTanks"].push_back({{"idTank", 1}, {"nameTank", "АИ-95"}});
+        response["fuelTanks"].push_back({{"idTank", 1}, {"visualNumberTank", 1}, {"nameTank", "АИ-95"}, {"isCheckEnoughFuel", 1}, {"allowanceTank", "100.0"}});
         
         res.status = 200;
         res.set_content(response.dump(), "application/json");
@@ -318,6 +356,32 @@ TEST_F(BackendTest, IntakeSuccess) {
     bool result = backend.Intake(1, 100.0, IntakeDirection::In);
     
     EXPECT_TRUE(result);
+}
+
+// Test allowanceTank handling when enough-fuel check is disabled
+TEST_F(BackendTest, AuthorizeSkipsAllowanceTankWhenCheckDisabled) {
+    mockServer->handleAuthorize = [](const httplib::Request& req [[maybe_unused]], httplib::Response& res) {
+        nlohmann::json response;
+        response["Token"] = "test-token-12345";
+        response["RoleId"] = 1;
+        response["Allowance"] = 50.0;
+        response["Price"] = 45.5;
+        response["fuelTanks"] = nlohmann::json::array();
+        response["fuelTanks"].push_back(
+            {{"idTank", 1},
+             {"visualNumberTank", 1},
+             {"nameTank", "АИ-95"},
+             {"isCheckEnoughFuel", 0},
+             {"allowanceTank", "3907.73"}});
+
+        res.status = 200;
+        res.set_content(response.dump(), "application/json");
+    };
+
+    Backend backend(baseAPI, controllerUid);
+    EXPECT_TRUE(backend.Authorize("card-uid-12345"));
+    ASSERT_EQ(backend.GetFuelTanks().size(), 1);
+    EXPECT_DOUBLE_EQ(backend.GetFuelTanks()[0].volume, 0.0);
 }
 
 // Test intake with customer role (should fail)
@@ -350,7 +414,7 @@ TEST_F(BackendTest, IntakeInvalidTank) {
         response["Allowance"] = nlohmann::json();
         response["Price"] = nlohmann::json();
         response["fuelTanks"] = nlohmann::json::array();
-        response["fuelTanks"].push_back({{"idTank", 1}, {"nameTank", "АИ-95"}});
+        response["fuelTanks"].push_back({{"idTank", 1}, {"visualNumberTank", 1}, {"nameTank", "АИ-95"}, {"isCheckEnoughFuel", 1}, {"allowanceTank", "100.0"}});
         
         res.status = 200;
         res.set_content(response.dump(), "application/json");
@@ -374,7 +438,7 @@ TEST_F(BackendTest, IntakeNegativeVolume) {
         response["Allowance"] = nlohmann::json();
         response["Price"] = nlohmann::json();
         response["fuelTanks"] = nlohmann::json::array();
-        response["fuelTanks"].push_back({{"idTank", 1}, {"nameTank", "АИ-95"}});
+        response["fuelTanks"].push_back({{"idTank", 1}, {"visualNumberTank", 1}, {"nameTank", "АИ-95"}, {"isCheckEnoughFuel", 1}, {"allowanceTank", "100.0"}});
         
         res.status = 200;
         res.set_content(response.dump(), "application/json");
@@ -546,7 +610,7 @@ TEST_F(BackendTest, IntakeJsonParseError) {
         response["Allowance"] = nlohmann::json();
         response["Price"] = nlohmann::json();
         response["fuelTanks"] = nlohmann::json::array();
-        response["fuelTanks"].push_back({{"idTank", 1}, {"nameTank", "АИ-95"}});
+        response["fuelTanks"].push_back({{"idTank", 1}, {"visualNumberTank", 1}, {"nameTank", "АИ-95"}, {"isCheckEnoughFuel", 1}, {"allowanceTank", "100.0"}});
         
         res.status = 200;
         res.set_content(response.dump(), "application/json");
@@ -565,4 +629,83 @@ TEST_F(BackendTest, IntakeJsonParseError) {
     
     EXPECT_FALSE(result);
     EXPECT_FALSE(backend.GetLastError().empty());
+}
+
+// Test that RefuelPayload maps visualNumberTank -> idTank in stored payload
+TEST_F(BackendTest, RefuelPayloadMapsVisualNumberToId) {
+    mockServer->handleAuthorize = [](const httplib::Request& req [[maybe_unused]], httplib::Response& res) {
+        nlohmann::json response;
+        response["Token"] = "test-token-12345";
+        response["RoleId"] = 1;
+        response["Allowance"] = 200.0;
+        response["Price"] = 45.5;
+        response["fuelTanks"] = nlohmann::json::array();
+        response["fuelTanks"].push_back(
+            {{"idTank", 44},
+             {"visualNumberTank", 7},
+             {"nameTank", "АИ-95"},
+             {"isCheckEnoughFuel", 1},
+             {"allowanceTank", "150.0"}});
+
+        res.status = 200;
+        res.set_content(response.dump(), "application/json");
+    };
+
+    mockServer->handleRefuel = [](const httplib::Request& req, httplib::Response& res) {
+        const auto body = nlohmann::json::parse(req.body);
+        EXPECT_EQ(body.value("TankNumber", -1), 44);
+
+        res.status = 200;
+        res.set_content("null", "application/json");
+    };
+
+    Backend backend(baseAPI, controllerUid);
+    EXPECT_TRUE(backend.Authorize("card-uid-12345"));
+
+    // Simulate a payload stored with the visual number (7, not idTank 44)
+    nlohmann::json storedPayload;
+    storedPayload["TankNumber"] = 7;
+    storedPayload["FuelVolume"] = 25.0;
+    storedPayload["TimeAt"] = 1234567890000LL;
+    EXPECT_TRUE(backend.RefuelPayload(storedPayload.dump()));
+}
+
+// Test that IntakePayload maps visualNumberTank -> idTank in stored payload
+TEST_F(BackendTest, IntakePayloadMapsVisualNumberToId) {
+    mockServer->handleAuthorize = [](const httplib::Request& req [[maybe_unused]], httplib::Response& res) {
+        nlohmann::json response;
+        response["Token"] = "operator-token";
+        response["RoleId"] = 2;  // Operator
+        response["Allowance"] = nlohmann::json();
+        response["Price"] = nlohmann::json();
+        response["fuelTanks"] = nlohmann::json::array();
+        response["fuelTanks"].push_back(
+            {{"idTank", 55},
+             {"visualNumberTank", 3},
+             {"nameTank", "ДТ"},
+             {"isCheckEnoughFuel", 0},
+             {"allowanceTank", "0"}});
+
+        res.status = 200;
+        res.set_content(response.dump(), "application/json");
+    };
+
+    mockServer->handleFuelIntake = [](const httplib::Request& req, httplib::Response& res) {
+        const auto body = nlohmann::json::parse(req.body);
+        EXPECT_EQ(body.value("TankNumber", -1), 55);
+
+        res.status = 200;
+        res.set_content("null", "application/json");
+    };
+
+    Backend backend(baseAPI, controllerUid);
+    EXPECT_TRUE(backend.Authorize("operator-card-uid"));
+
+    // Simulate a payload stored with the visual number (3, not idTank 55)
+    nlohmann::json storedPayload;
+    storedPayload["TankNumber"] = 3;
+    storedPayload["IntakeVolume"] = 100.0;
+    storedPayload["Direction"] = 1;
+    storedPayload["TimeAt"] = 1234567890000LL;
+    EXPECT_TRUE(backend.IntakePayload(storedPayload.dump()));
 }

--- a/tests/controller_test.cpp
+++ b/tests/controller_test.cpp
@@ -654,7 +654,7 @@ TEST_F(ControllerTest, CancelNoFuelInRefuelingBehavesLikeCancelPressed) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
     mockBackend->price_ = 1.0;
-    mockBackend->tanksStorage_ = { BackendTankInfo{1, "Tank A"} };
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 1, "Tank A"} };
 
     EXPECT_CALL(*mockBackend, Authorize("customer-card")).WillOnce([this]() {
         mockBackend->authorized_ = true;
@@ -688,7 +688,7 @@ TEST_F(ControllerTest, NoFlowWatchdogCancelsRefueling) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
     mockBackend->price_ = 1.0;
-    mockBackend->tanksStorage_ = { BackendTankInfo{1, "Tank A"} };
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 1, "Tank A"} };
 
     EXPECT_CALL(*mockBackend, Authorize("customer-card")).WillOnce([this]() {
         mockBackend->authorized_ = true;
@@ -719,7 +719,7 @@ TEST_F(ControllerTest, RefuelingCompletionDisplaysFinalVolume) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
     mockBackend->price_ = 1.0;
-    mockBackend->tanksStorage_ = { BackendTankInfo{1, "Tank A"} };
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 1, "Tank A"} };
 
     EXPECT_CALL(*mockBackend, Authorize("customer-card")).WillOnce([this]() {
         mockBackend->authorized_ = true;
@@ -943,8 +943,9 @@ TEST_F(ControllerTest, InputLengthLimit) {
         controller->addDigitToInput('9');
     }
     
-    // Should be limited to 10
-    EXPECT_LE(controller->getCurrentInput().length(), 10);
+    // Controller allows long input up to a high safety threshold
+    EXPECT_EQ(controller->getCurrentInput().length(), 15);
+    EXPECT_LE(controller->getCurrentInput().length(), 1024);
 }
 
 // Test PIN entry started event
@@ -1043,6 +1044,36 @@ TEST_F(ControllerTest, TankValidationWithAvailableTanks) {
     EXPECT_FALSE(controller->isTankValid(3));
 }
 
+TEST_F(ControllerTest, TankValidationUsesVisualTankNumberFromBackend) {
+    mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
+    mockBackend->allowance_ = 100.0;
+    mockBackend->price_ = 45.5;
+    mockBackend->tanksStorage_ = {BackendTankInfo{44, 7, "Tank A", 50.0}};
+
+    EXPECT_CALL(*mockBackend, Authorize("test-card"))
+        .WillOnce(Return(true));
+    controller->initialize();
+
+    std::thread controllerThread([this]() {
+        controller->run();
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    controller->handleCardPresented("test-card");
+    ASSERT_TRUE(waitForState(SystemState::TankSelection));
+
+    EXPECT_TRUE(controller->isTankValid(7));
+    EXPECT_FALSE(controller->isTankValid(44));
+
+    controller->selectTank(7);
+    ASSERT_TRUE(waitForState(SystemState::VolumeEntry));
+
+    controller->enterVolume(40.0);
+    ASSERT_TRUE(waitForState(SystemState::Refueling));
+
+    shutdownControllerAndJoinThread(controllerThread);
+}
+
 // Test invalid volume entry
 TEST_F(ControllerTest, InvalidVolumeEntry) {
     controller->initialize();
@@ -1132,7 +1163,7 @@ TEST_F(ControllerTest, InputClearedAfterValidationError) {
 
 TEST_F(ControllerTest, OperatorIntakeWorkflow) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Operator);
-    mockBackend->tanksStorage_ = {BackendTankInfo{1, "Tank A"}};
+    mockBackend->tanksStorage_ = {BackendTankInfo{1, 1, "Tank A"}};
 
     EXPECT_CALL(*mockBackend, Authorize("operator-card"))
         .WillOnce(Return(true));
@@ -1172,7 +1203,7 @@ TEST_F(ControllerTest, CustomerRefuelWorkflow) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 200.0;
     mockBackend->price_ = 45.5;
-    mockBackend->tanksStorage_ = {BackendTankInfo{1, "Tank A"}};
+    mockBackend->tanksStorage_ = {BackendTankInfo{1, 1, "Tank A"}};
 
     EXPECT_CALL(*mockBackend, Authorize("customer-card"))
         .WillOnce(Return(true));
@@ -1254,7 +1285,7 @@ TEST_F(ControllerTest, DisplayMessagePinEntryState) {
 TEST_F(ControllerTest, DisplayMessageTankSelectionState) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
-    mockBackend->tanksStorage_ = {BackendTankInfo{1, "Tank A"}, BackendTankInfo{2, "Tank B"}};
+    mockBackend->tanksStorage_ = {BackendTankInfo{1, 1, "Tank A"}, BackendTankInfo{2, 2, "Tank B"}};
     
     EXPECT_CALL(*mockBackend, Authorize("test-card"))
         .WillOnce(Return(true));
@@ -1286,7 +1317,7 @@ TEST_F(ControllerTest, DisplayMessageTankSelectionState) {
 TEST_F(ControllerTest, DisplayMessageVolumeEntryState) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
-    mockBackend->tanksStorage_ = {BackendTankInfo{1, "Tank A"}};
+    mockBackend->tanksStorage_ = {BackendTankInfo{1, 1, "Tank A"}};
     
     EXPECT_CALL(*mockBackend, Authorize("test-card"))
         .WillOnce(Return(true));
@@ -1387,7 +1418,7 @@ TEST_F(ControllerTest, CardReadingReenabledWhenReturningToWaiting) {
 TEST_F(ControllerTest, CardReadingDisabledDuringAuthorization) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
-    mockBackend->tanksStorage_ = {BackendTankInfo{1, "Tank A"}};
+    mockBackend->tanksStorage_ = {BackendTankInfo{1, 1, "Tank A"}};
     
     EXPECT_CALL(*mockBackend, Authorize("test-card")).WillOnce(Return(true));
     
@@ -1417,7 +1448,7 @@ TEST_F(ControllerTest, CardReadingDisabledDuringAuthorization) {
 TEST_F(ControllerTest, CardReadingDisabledDuringRefueling) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
-    mockBackend->tanksStorage_ = {BackendTankInfo{1, "Tank A"}};
+    mockBackend->tanksStorage_ = {BackendTankInfo{1, 1, "Tank A"}};
     
     EXPECT_CALL(*mockBackend, Authorize("test-card")).WillOnce(Return(true));
     EXPECT_CALL(*mockBackend, Refuel(1, 10.0)).WillOnce(Return(true));
@@ -1474,7 +1505,7 @@ TEST_F(ControllerTest, DataTransmissionStateShownDuringRefuel) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
     mockBackend->price_ = 1.0;
-    mockBackend->tanksStorage_ = { BackendTankInfo{1, "Tank A"} };
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 1, "Tank A"} };
 
     EXPECT_CALL(*mockBackend, Authorize("customer-card")).WillOnce([this]() {
         mockBackend->authorized_ = true;
@@ -1539,7 +1570,7 @@ TEST_F(ControllerTest, DataTransmissionStateShownDuringIntake) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Operator);
     mockBackend->allowance_ = 0.0;
     mockBackend->price_ = 0.0;
-    mockBackend->tanksStorage_ = { BackendTankInfo{1, "Tank A"} };
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 1, "Tank A"} };
 
     EXPECT_CALL(*mockBackend, Authorize("operator-card")).WillOnce([this]() {
         mockBackend->authorized_ = true;
@@ -1611,6 +1642,8 @@ TEST_F(ControllerTest, VolumeValidationAgainstTankCapacity) {
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 50.0;
     mockBackend->tanksStorage_ = { tank1 };
@@ -1653,6 +1686,8 @@ TEST_F(ControllerTest, VolumeValidationWithinTankCapacity) {
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 50.0;
     mockBackend->tanksStorage_ = { tank1 };
@@ -1694,6 +1729,8 @@ TEST_F(ControllerTest, VolumeValidationEqualToTankCapacity) {
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 50.0;
     mockBackend->tanksStorage_ = { tank1 };
@@ -1735,6 +1772,8 @@ TEST_F(ControllerTest, VolumeValidationAgainstAllowanceWhenLowerThanTankCapacity
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 100.0;
     mockBackend->tanksStorage_ = { tank1 };
@@ -1777,6 +1816,8 @@ TEST_F(ControllerTest, VolumeValidationBothConstraintsSatisfied) {
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 50.0;
     mockBackend->tanksStorage_ = { tank1 };
@@ -1820,6 +1861,8 @@ TEST_F(ControllerTest, OperatorNotRestrictedByTankCapacity) {
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 50.0;
     mockBackend->tanksStorage_ = { tank1 };
@@ -1861,6 +1904,8 @@ TEST_F(ControllerTest, VolumeValidationWithZeroTankCapacity) {
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 0.0;  // Zero capacity
     mockBackend->tanksStorage_ = { tank1 };
@@ -1902,9 +1947,13 @@ TEST_F(ControllerTest, VolumeValidationMultipleTanks) {
     
     BackendTankInfo tank1, tank2;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 30.0;
     tank2.idTank = 2;
+    tank2.visualNumberTank = 2;
+    
     tank2.nameTank = "Tank B";
     tank2.volume = 50.0;
     mockBackend->tanksStorage_ = { tank1, tank2 };
@@ -1944,7 +1993,7 @@ TEST_F(ControllerTest, TankVolumeFromBackendAuthorization) {
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
     mockBackend->price_ = 1.0;
-    mockBackend->tanksStorage_ = { BackendTankInfo{1, "Tank A", 75.5} };  // Fractional volume
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 1, "Tank A", 75.5} };  // Fractional volume
 
     EXPECT_CALL(*mockBackend, Authorize("customer-card")).WillOnce([this]() {
         mockBackend->authorized_ = true;
@@ -1975,6 +2024,8 @@ TEST_F(ControllerTest, GetTankVolumeDirectTest) {
     // Set up tank with volume
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 50.0;
     mockBackend->tanksStorage_ = { tank1 };
@@ -1998,6 +2049,8 @@ TEST_F(ControllerTest, VolumeEntryDisplayShowsAllowanceWhenLower) {
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 100.0;
     mockBackend->tanksStorage_ = { tank1 };
@@ -2049,6 +2102,8 @@ TEST_F(ControllerTest, VolumeEntryDisplayShowsTankVolumeWhenLower) {
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 40.0;
     mockBackend->tanksStorage_ = { tank1 };
@@ -2100,6 +2155,8 @@ TEST_F(ControllerTest, VolumeEntryDisplayShowsAllowanceWhenNoTankVolume) {
     
     BackendTankInfo tank1;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 0.0;  // No volume specified
     mockBackend->tanksStorage_ = { tank1 };
@@ -2151,9 +2208,13 @@ TEST_F(ControllerTest, VolumeEntryDisplayWithMultipleTanksDifferentVolumes) {
     
     BackendTankInfo tank1, tank2;
     tank1.idTank = 1;
+    tank1.visualNumberTank = 1;
+    
     tank1.nameTank = "Tank A";
     tank1.volume = 30.0;
     tank2.idTank = 2;
+    tank2.visualNumberTank = 2;
+    
     tank2.nameTank = "Tank B";
     tank2.volume = 70.0;
     mockBackend->tanksStorage_ = { tank1, tank2 };
@@ -2470,7 +2531,7 @@ TEST_F(ControllerTest, NotAuthorizedStateRetriesAuthorization) {
 
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
-    mockBackend->tanksStorage_ = { BackendTankInfo{1, "Tank A"} };
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 1, "Tank A"} };
 
     EXPECT_CALL(*mockBackend, Authorize("valid-card"))
         .WillOnce([this]() {
@@ -2510,7 +2571,7 @@ TEST_F(ControllerTest, CannotAuthorizeStateRetriesAuthorization) {
 
     mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
     mockBackend->allowance_ = 100.0;
-    mockBackend->tanksStorage_ = { BackendTankInfo{1, "Tank A"} };
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 1, "Tank A"} };
 
     controller->initialize();
 

--- a/tests/controller_test.cpp
+++ b/tests/controller_test.cpp
@@ -938,14 +938,16 @@ TEST_F(ControllerTest, MultipleShutdown) {
 TEST_F(ControllerTest, InputLengthLimit) {
     controller->initialize();
     
-    // Add more than 10 digits
-    for (int i = 0; i < 15; i++) {
+    // Fill input exactly to the safety cap
+    for (std::size_t i = 0; i < INPUT_MAX_LENGTH; i++) {
         controller->addDigitToInput('9');
     }
-    
-    // Controller allows long input up to a high safety threshold
-    EXPECT_EQ(controller->getCurrentInput().length(), 15);
-    EXPECT_LE(controller->getCurrentInput().length(), 1024);
+    EXPECT_EQ(controller->getCurrentInput().length(), INPUT_MAX_LENGTH);
+
+    // Digits beyond the cap must be silently discarded
+    controller->addDigitToInput('1');
+    controller->addDigitToInput('2');
+    EXPECT_EQ(controller->getCurrentInput().length(), INPUT_MAX_LENGTH);
 }
 
 // Test PIN entry started event


### PR DESCRIPTION
The hard-coded `1024` safety cap in `addDigitToInput()` lacked a named constant and its comment was inaccurate (claimed input was "not limited" despite enforcing a cap, with typos). The `InputLengthLimit` test only added 15 digits and never actually exercised the boundary.

## Changes

- **`include/config.h`** – Adds `constexpr std::size_t INPUT_MAX_LENGTH = 1024` with a comment clarifying it is a safety cap against abnormal/chained conditions, not a normal operational limit
- **`src/controller.cpp`** – `addDigitToInput()` uses `INPUT_MAX_LENGTH` instead of the magic number; comment rewritten to accurately describe the guard
- **`tests/controller_test.cpp`** – `InputLengthLimit` now fills the buffer to exactly `INPUT_MAX_LENGTH`, then asserts further digits are silently discarded, making regressions detectable

```cpp
// Before
// In reality we do not limit input length
// This is unreasomably large number t protect against abnormal conditions
if (currentInput_.length() < 1024) {

// After
// Normal inputs are far shorter than INPUT_MAX_LENGTH; this cap protects
// against abnormal or chained conditions that could grow the buffer indefinitely.
if (currentInput_.length() < INPUT_MAX_LENGTH) {
```