### PR TITLE
Fix offline tank validation and tank fetch error handling

### DIFF
--- a/include/backend.h
+++ b/include/backend.h
@@ -37,6 +37,14 @@ struct UserCard {
     double allowance = 0.0;
 };
 
+// Fuel tank structure for cache population
+struct FuelTank {
+    int idTank = 0;
+    int visualNumberTank = 0;
+    std::string nameTank;
+    Volume volume = 0.0;
+};
+
 // Interface for backend communication to enable mocking in tests
 class IBackend {
 public:
@@ -56,6 +64,7 @@ public:
     virtual const std::string& GetLastError() const = 0;
     virtual bool IsNetworkError() const = 0;
     virtual std::vector<UserCard> FetchUserCards(int first, int number) = 0;
+    virtual std::vector<FuelTank> FetchFuelTanks(int first, int number) = 0;
     virtual const std::string& GetControllerUid() const = 0;
 };
 
@@ -94,6 +103,7 @@ public:
     const std::string& GetLastError() const override { return lastError_; }
     bool IsNetworkError() const override { return networkError_; }
     std::vector<UserCard> FetchUserCards(int first, int number) override;
+    std::vector<FuelTank> FetchFuelTanks(int first, int number) override;
     const std::string& GetControllerUid() const override { return controllerUid_; }
 
 protected:

--- a/include/controller.h
+++ b/include/controller.h
@@ -180,6 +180,7 @@ class Controller {
     // Current session state
     UserInfo currentUser_;
     std::vector<TankInfo> availableTanks_;
+    std::vector<BackendTankInfo> cachedFuelTanks_;
     TankNumber selectedTank_;
     Volume enteredVolume_;
     std::string currentInput_;

--- a/include/user_cache.h
+++ b/include/user_cache.h
@@ -20,6 +20,13 @@ struct UserCacheEntry {
     int roleId = 0;
 };
 
+struct TankCacheEntry {
+    int idTank = 0;
+    int visualNumberTank = 0;
+    std::string nameTank;
+    double volume = 0.0;
+};
+
 // User cache class with flip/flop table mechanism for atomic updates
 class UserCache {
 public:
@@ -36,10 +43,13 @@ public:
     bool UpdateEntry(const std::string& uid, double allowance, int roleId);
     bool DeductAllowance(const std::string& uid, double amount);
     int GetCount() const;
+    std::vector<TankCacheEntry> GetTanks() const;
+    int GetTankCount() const;
 
     // Population operations with flip/flop mechanism
     bool BeginPopulation();
     bool AddPopulationEntry(const std::string& uid, double allowance, int roleId);
+    bool AddPopulationTank(int idTank, int visualNumberTank, const std::string& nameTank, double volume);
     bool CommitPopulation();
     void AbortPopulation();
 

--- a/src/backend_base.cpp
+++ b/src/backend_base.cpp
@@ -588,7 +588,7 @@ std::vector<FuelTank> BackendBase::FetchFuelTanks(int first, int number) {
                 if (item["Volume"].is_number()) {
                     tank.volume = item["Volume"].get<double>();
                 } else {
-                    LOG_BCK_ERROR("Invalid response format: expected array");
+                    LOG_BCK_ERROR("Invalid response format: field 'Volume' must be a number");
                     lastError_ = StdBackendError;
                     return std::vector<FuelTank>{};
                 }

--- a/src/backend_base.cpp
+++ b/src/backend_base.cpp
@@ -539,4 +539,74 @@ std::vector<UserCard> BackendBase::FetchUserCards(int first, int number) {
     return result;
 }
 
+std::vector<FuelTank> BackendBase::FetchFuelTanks(int first, int number) {
+    std::vector<FuelTank> result;
+
+    try {
+        std::string endpoint = "/api/pump/tanks?first=" + std::to_string(first) +
+                               "&number=" + std::to_string(number);
+
+        LOG_BCK_INFO("Fetching fuel tanks: first={}, number={}", first, number);
+
+        nlohmann::json requestBody;
+        requestBody["PumpControllerUid"] = controllerUid_;
+
+        nlohmann::json response = HttpRequestWrapper(endpoint, "POST", requestBody, true);
+
+        std::string responseError;
+        if (IsErrorResponse(response, &responseError)) {
+            LOG_BCK_ERROR("Failed to fetch fuel tanks: {}", responseError);
+            lastError_ = responseError;
+            return result;
+        }
+
+        if (!response.is_array()) {
+            LOG_BCK_ERROR("Invalid response format: expected array");
+            lastError_ = StdBackendError;
+            return result;
+        }
+
+        for (const auto& item : response) {
+            if (!item.is_object()) {
+                continue;
+            }
+
+            if (!item.contains("VisualNumberTank") || !item["VisualNumberTank"].is_number_integer()) {
+                continue;
+            }
+
+            FuelTank tank;
+            tank.visualNumberTank = item["VisualNumberTank"].get<int>();
+
+            if (item.contains("IdTank") && item["IdTank"].is_number_integer()) {
+                tank.idTank = item["IdTank"].get<int>();
+            }
+            if (item.contains("NameTank") && item["NameTank"].is_string()) {
+                tank.nameTank = item["NameTank"].get<std::string>();
+            }
+            if (item.contains("Volume") && !item["Volume"].is_null()) {
+                if (item["Volume"].is_number()) {
+                    tank.volume = item["Volume"].get<double>();
+                } else {
+                    LOG_BCK_ERROR("Invalid response format: expected array");
+                    lastError_ = StdBackendError;
+                    return std::vector<FuelTank>{};
+                }
+            }
+
+            result.push_back(tank);
+        }
+
+        LOG_BCK_INFO("Fetched {} fuel tanks", result.size());
+        lastError_.clear();
+    } catch (const std::exception& e) {
+        LOG_BCK_ERROR("Failed to fetch fuel tanks: {}", e.what());
+        if (lastError_.empty()) {
+            lastError_ = StdBackendError;
+        }
+    }
+
+    return result;
+}
+
 } // namespace fuelflux

--- a/src/cache_manager.cpp
+++ b/src/cache_manager.cpp
@@ -213,6 +213,7 @@ bool CacheManager::PopulateCache() {
         }
         
         int totalFetched = 0;
+        int totalTanksFetched = 0;
         int first = 0;
         bool moreData = true;
         
@@ -246,6 +247,34 @@ bool CacheManager::PopulateCache() {
             
             first += kFetchBatchSize;
         }
+
+        first = 0;
+        moreData = true;
+        while (moreData && running_) {
+            LOG_DEBUG("Fetching fuel tanks: first={}, number={}", first, kFetchBatchSize);
+            std::vector<FuelTank> tanks = backend_->FetchFuelTanks(first, kFetchBatchSize);
+
+            if (tanks.empty()) {
+                moreData = false;
+                break;
+            }
+
+            for (const auto& tank : tanks) {
+                if (!cache_->AddPopulationTank(tank.idTank, tank.visualNumberTank, tank.nameTank, tank.volume)) {
+                    LOG_ERROR("Failed to add tank cache entry for visual tank: {}", tank.visualNumberTank);
+                    cache_->AbortPopulation();
+                    backend_->Deauthorize();
+                    return false;
+                }
+            }
+
+            totalTanksFetched += static_cast<int>(tanks.size());
+            if (static_cast<int>(tanks.size()) < kFetchBatchSize) {
+                moreData = false;
+            }
+
+            first += kFetchBatchSize;
+        }
         
         if (!running_) {
             LOG_WARN("Cache population interrupted by shutdown");
@@ -261,7 +290,8 @@ bool CacheManager::PopulateCache() {
             return false;
         }
         
-        LOG_INFO("Cache population completed: {} entries loaded", totalFetched);
+        LOG_INFO("Cache population completed: {} card entries loaded, {} tank entries loaded",
+                 totalFetched, totalTanksFetched);
         
         // Close synchronization session - this is critical for cleanup
         // If deauthorization fails, we still return true because the data was successfully loaded

--- a/src/cache_manager.cpp
+++ b/src/cache_manager.cpp
@@ -255,6 +255,13 @@ bool CacheManager::PopulateCache() {
             std::vector<FuelTank> tanks = backend_->FetchFuelTanks(first, kFetchBatchSize);
 
             if (tanks.empty()) {
+                const std::string lastError = backend_->GetLastError();
+                if (!lastError.empty()) {
+                    LOG_ERROR("Failed to fetch fuel tanks: {}", lastError);
+                    cache_->AbortPopulation();
+                    backend_->Deauthorize();
+                    return false;
+                }
                 moreData = false;
                 break;
             }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -497,10 +497,12 @@ void Controller::requestAuthorization(const UserId& userId) {
         currentUser_.price = backend_->GetPrice();
 
         availableTanks_.clear();
+        cachedFuelTanks_.clear();
         for (const auto& tank : backend_->GetFuelTanks()) {
             TankInfo info;
             info.number = tank.visualNumberTank;
             availableTanks_.push_back(info);
+            cachedFuelTanks_.push_back(tank);
         }
         
         // Update cache with authorization data
@@ -525,6 +527,20 @@ void Controller::requestAuthorization(const UserId& userId) {
                 currentUser_.allowance = cached->allowance;
                 currentUser_.price = 0.0;
                 availableTanks_.clear();
+                cachedFuelTanks_.clear();
+                const auto cachedTanks = userCache_->GetTanks();
+                for (const auto& tank : cachedTanks) {
+                    TankInfo info;
+                    info.number = tank.visualNumberTank;
+                    availableTanks_.push_back(info);
+
+                    BackendTankInfo cachedInfo;
+                    cachedInfo.idTank = tank.idTank;
+                    cachedInfo.visualNumberTank = tank.visualNumberTank;
+                    cachedInfo.nameTank = tank.nameTank;
+                    cachedInfo.volume = tank.volume;
+                    cachedFuelTanks_.push_back(cachedInfo);
+                }
                 LOG_CTRL_WARN("Authorized user {} from cache due to backend network error", userId);
                 postEvent(Event::AuthorizationSuccess);
                 return;
@@ -569,6 +585,15 @@ bool Controller::isTankValid(TankNumber tankNumber) const {
 }
 
 Volume Controller::getTankVolume(TankNumber tankNumber) const {
+    if (sessionAuthorizedFromCache_) {
+        for (const auto& tank : cachedFuelTanks_) {
+            if (tank.visualNumberTank == tankNumber) {
+                return tank.volume;
+            }
+        }
+        return 0.0;
+    }
+
     if (backend_) {
         const auto& tanks = backend_->GetFuelTanks();
         for (const auto& tank : tanks) {
@@ -887,6 +912,7 @@ TankNumber Controller::parseTankFromInput() const {
 void Controller::resetSessionData() {
     currentUser_ = UserInfo{};
     availableTanks_.clear();
+    cachedFuelTanks_.clear();
     selectedTank_ = 0;
     enteredVolume_ = 0.0;
     selectedIntakeDirection_ = IntakeDirection::In;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -572,10 +572,6 @@ void Controller::selectTank(TankNumber tankNumber) {
 }
 
 bool Controller::isTankValid(TankNumber tankNumber) const {
-    if (sessionAuthorizedFromCache_) {
-        return tankNumber > 0;
-    }
-
     for (const auto& tank : availableTanks_) {
         if (tank.number == tankNumber) {
             return true;

--- a/src/user_cache.cpp
+++ b/src/user_cache.cpp
@@ -35,6 +35,8 @@ UserCache::UserCache(const std::string& dbPath)
     // Create both tables for flip/flop mechanism
     Execute("CREATE TABLE IF NOT EXISTS user_cache_a (uid TEXT PRIMARY KEY, allowance REAL NOT NULL, role_id INTEGER NOT NULL);");
     Execute("CREATE TABLE IF NOT EXISTS user_cache_b (uid TEXT PRIMARY KEY, allowance REAL NOT NULL, role_id INTEGER NOT NULL);");
+    Execute("CREATE TABLE IF NOT EXISTS tank_cache_a (id_tank INTEGER NOT NULL, visual_number_tank INTEGER PRIMARY KEY, name_tank TEXT NOT NULL, volume REAL NOT NULL);");
+    Execute("CREATE TABLE IF NOT EXISTS tank_cache_b (id_tank INTEGER NOT NULL, visual_number_tank INTEGER PRIMARY KEY, name_tank TEXT NOT NULL, volume REAL NOT NULL);");
     
     // Create metadata table to track which table is active
     Execute("CREATE TABLE IF NOT EXISTS user_cache_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);");
@@ -262,6 +264,55 @@ int UserCache::GetCount() const {
     return count;
 }
 
+std::vector<TankCacheEntry> UserCache::GetTanks() const {
+    std::lock_guard<std::mutex> lock(dbMutex_);
+    std::vector<TankCacheEntry> result;
+    if (!db_) {
+        return result;
+    }
+
+    std::string activeSuffix = activeTableIsA_ ? "a" : "b";
+    const std::string sql = "SELECT id_tank, visual_number_tank, name_tank, volume FROM tank_cache_" +
+                            activeSuffix + " ORDER BY visual_number_tank ASC;";
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db_, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
+        return result;
+    }
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        TankCacheEntry entry;
+        entry.idTank = sqlite3_column_int(stmt, 0);
+        entry.visualNumberTank = sqlite3_column_int(stmt, 1);
+        const auto* name = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 2));
+        entry.nameTank = name ? name : "";
+        entry.volume = sqlite3_column_double(stmt, 3);
+        result.push_back(entry);
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}
+
+int UserCache::GetTankCount() const {
+    std::lock_guard<std::mutex> lock(dbMutex_);
+    if (!db_) {
+        return 0;
+    }
+
+    std::string activeSuffix = activeTableIsA_ ? "a" : "b";
+    const std::string sql = "SELECT COUNT(*) FROM tank_cache_" + activeSuffix + ";";
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db_, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
+        return 0;
+    }
+
+    int count = 0;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        count = sqlite3_column_int(stmt, 0);
+    }
+    sqlite3_finalize(stmt);
+    return count;
+}
+
 bool UserCache::BeginPopulation() {
     std::lock_guard<std::mutex> lock(dbMutex_);
     if (!db_ || populationInProgress_) {
@@ -273,6 +324,14 @@ bool UserCache::BeginPopulation() {
     char* errorMessage = nullptr;
     const int result = sqlite3_exec(db_, sql.c_str(), nullptr, nullptr, &errorMessage);
     if (result != SQLITE_OK) {
+        sqlite3_free(errorMessage);
+        return false;
+    }
+
+    std::string standbySuffix = activeTableIsA_ ? "b" : "a";
+    std::string tankSql = "DELETE FROM tank_cache_" + standbySuffix + ";";
+    const int tankResult = sqlite3_exec(db_, tankSql.c_str(), nullptr, nullptr, &errorMessage);
+    if (tankResult != SQLITE_OK) {
         sqlite3_free(errorMessage);
         return false;
     }
@@ -296,6 +355,30 @@ bool UserCache::AddPopulationEntry(const std::string& uid, double allowance, int
     sqlite3_bind_text(stmt, 1, uid.c_str(), -1, SQLITE_TRANSIENT);
     sqlite3_bind_double(stmt, 2, allowance);
     sqlite3_bind_int(stmt, 3, roleId);
+
+    const bool ok = (sqlite3_step(stmt) == SQLITE_DONE);
+    sqlite3_finalize(stmt);
+    return ok;
+}
+
+bool UserCache::AddPopulationTank(int idTank, int visualNumberTank, const std::string& nameTank, double volume) {
+    std::lock_guard<std::mutex> lock(dbMutex_);
+    if (!db_ || !populationInProgress_) {
+        return false;
+    }
+
+    std::string standbySuffix = activeTableIsA_ ? "b" : "a";
+    std::string sql = "INSERT OR REPLACE INTO tank_cache_" + standbySuffix +
+                      " (id_tank, visual_number_tank, name_tank, volume) VALUES (?, ?, ?, ?);";
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db_, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
+        return false;
+    }
+
+    sqlite3_bind_int(stmt, 1, idTank);
+    sqlite3_bind_int(stmt, 2, visualNumberTank);
+    sqlite3_bind_text(stmt, 3, nameTank.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_double(stmt, 4, volume);
 
     const bool ok = (sqlite3_step(stmt) == SQLITE_DONE);
     sqlite3_finalize(stmt);

--- a/tests/backend_base_test.cpp
+++ b/tests/backend_base_test.cpp
@@ -144,3 +144,65 @@ TEST(BackendBaseFetchUserCardsTest, BadAllowanceTypeIsHandledAsFailure) {
     EXPECT_TRUE(cards.empty());
     EXPECT_EQ(backend.GetLastError(), StdBackendError);
 }
+
+
+TEST(BackendBaseFetchFuelTanksTest, SendsExpectedRequestAndParsesValidTanks) {
+    TestBackendBase backend("controller-uid-42");
+
+    backend.boolTokenHandler = [](const std::string& endpoint,
+                                  const std::string& method,
+                                  const nlohmann::json& body,
+                                  bool useBearerToken) -> nlohmann::json {
+        EXPECT_EQ(endpoint, "/api/pump/tanks?first=2&number=2");
+        EXPECT_EQ(method, "POST");
+        EXPECT_TRUE(useBearerToken);
+        EXPECT_EQ(body.value("PumpControllerUid", ""), "controller-uid-42");
+
+        return nlohmann::json::array({
+            {{"VisualNumberTank", 1}, {"IdTank", 11}, {"NameTank", "Diesel"}, {"Volume", 1000.5}},
+            {{"VisualNumberTank", 2}},
+            7,
+            {{"IdTank", 99}},
+        });
+    };
+
+    const auto tanks = backend.FetchFuelTanks(2, 2);
+
+    ASSERT_EQ(tanks.size(), 2);
+    EXPECT_EQ(tanks[0].visualNumberTank, 1);
+    EXPECT_EQ(tanks[0].idTank, 11);
+    EXPECT_EQ(tanks[0].nameTank, "Diesel");
+    EXPECT_DOUBLE_EQ(tanks[0].volume, 1000.5);
+
+    EXPECT_EQ(tanks[1].visualNumberTank, 2);
+    EXPECT_EQ(tanks[1].idTank, 0);
+    EXPECT_TRUE(tanks[1].nameTank.empty());
+    EXPECT_DOUBLE_EQ(tanks[1].volume, 0.0);
+    EXPECT_TRUE(backend.GetLastError().empty());
+}
+
+TEST(BackendBaseFetchFuelTanksTest, ErrorResponseReturnsEmptyAndStoresMessage) {
+    TestBackendBase backend("controller-uid-42");
+
+    backend.boolTokenHandler = [](const std::string&, const std::string&, const nlohmann::json&, bool) {
+        return nlohmann::json{{"CodeError", 9}, {"TextError", "tanks api unavailable"}};
+    };
+
+    const auto tanks = backend.FetchFuelTanks(0, 100);
+
+    EXPECT_TRUE(tanks.empty());
+    EXPECT_EQ(backend.GetLastError(), "tanks api unavailable");
+}
+
+TEST(BackendBaseFetchFuelTanksTest, BadVolumeTypeIsHandledAsFailure) {
+    TestBackendBase backend("controller-uid-42");
+
+    backend.boolTokenHandler = [](const std::string&, const std::string&, const nlohmann::json&, bool) {
+        return nlohmann::json::array({{{"VisualNumberTank", 1}, {"Volume", "bad"}}});
+    };
+
+    const auto tanks = backend.FetchFuelTanks(0, 1);
+
+    EXPECT_TRUE(tanks.empty());
+    EXPECT_EQ(backend.GetLastError(), StdBackendError);
+}

--- a/tests/backlog_worker_test.cpp
+++ b/tests/backlog_worker_test.cpp
@@ -29,6 +29,7 @@ public:
     MOCK_METHOD(const std::string&, GetLastError, (), (const, override));
     MOCK_METHOD(bool, IsNetworkError, (), (const, override));
     MOCK_METHOD(std::vector<UserCard>, FetchUserCards, (int first, int number), (override));
+    MOCK_METHOD(std::vector<FuelTank>, FetchFuelTanks, (int first, int number), (override));
     MOCK_METHOD(const std::string&, GetControllerUid, (), (const, override));
 };
 

--- a/tests/cache_manager_test.cpp
+++ b/tests/cache_manager_test.cpp
@@ -38,6 +38,7 @@ public:
     MOCK_METHOD((const std::string&), GetLastError, (), (const, override));
     MOCK_METHOD(bool, IsNetworkError, (), (const, override));
     MOCK_METHOD(std::vector<UserCard>, FetchUserCards, (int first, int number), (override));
+    MOCK_METHOD(std::vector<FuelTank>, FetchFuelTanks, (int first, int number), (override));
     MOCK_METHOD((const std::string&), GetControllerUid, (), (const, override));
 };
 
@@ -97,6 +98,10 @@ TEST_F(CacheManagerTest, StartPerformsInitialPaginatedPopulation) {
         {"uid-100", 1, 555.0},
         {"uid-101", 2, 777.0},
     };
+    std::vector<FuelTank> tanksBatch = {
+        {11, 1, "Tank-1", 5000.0},
+        {12, 2, "Tank-2", 7000.0},
+    };
 
     std::string controllerUid = "test-controller-uid";
     
@@ -110,6 +115,7 @@ TEST_F(CacheManagerTest, StartPerformsInitialPaginatedPopulation) {
         // Data fetching
         EXPECT_CALL(*backend, FetchUserCards(0, 100)).WillOnce(Return(firstBatch));
         EXPECT_CALL(*backend, FetchUserCards(100, 100)).WillOnce(Return(secondBatch));
+        EXPECT_CALL(*backend, FetchFuelTanks(0, 100)).WillOnce(Return(tanksBatch));
         
         // Synchronization session cleanup
         EXPECT_CALL(*backend, Deauthorize()).WillOnce(Return(true));
@@ -124,6 +130,7 @@ TEST_F(CacheManagerTest, StartPerformsInitialPaginatedPopulation) {
     ASSERT_TRUE(WaitForPopulation(manager, before));
     EXPECT_TRUE(manager.GetLastPopulationSuccess());
     EXPECT_EQ(cache->GetCount(), 102);
+    EXPECT_EQ(cache->GetTankCount(), 2);
 
     auto last = cache->GetEntry("uid-101");
     ASSERT_TRUE(last.has_value());
@@ -139,6 +146,8 @@ TEST_F(CacheManagerTest, TriggerPopulationReplacesActiveTableWithFreshData) {
 
     std::vector<UserCard> initial = {{"uid-initial", 1, 100.0}};
     std::vector<UserCard> refreshed = {{"uid-refreshed", 2, 42.5}};
+    std::vector<FuelTank> initialTanks = {{21, 1, "Tank-A", 1000.0}};
+    std::vector<FuelTank> refreshedTanks = {{22, 2, "Tank-B", 2000.0}};
 
     std::string controllerUid = "test-controller-uid";
     
@@ -149,6 +158,7 @@ TEST_F(CacheManagerTest, TriggerPopulationReplacesActiveTableWithFreshData) {
         EXPECT_CALL(*backend, Authorize(controllerUid)).WillOnce(Return(true));
         EXPECT_CALL(*backend, GetRoleId()).WillOnce(Return(3));
         EXPECT_CALL(*backend, FetchUserCards(0, 100)).WillOnce(Return(initial));
+        EXPECT_CALL(*backend, FetchFuelTanks(0, 100)).WillOnce(Return(initialTanks));
         EXPECT_CALL(*backend, Deauthorize()).WillOnce(Return(true));
         
         // Second population
@@ -156,6 +166,7 @@ TEST_F(CacheManagerTest, TriggerPopulationReplacesActiveTableWithFreshData) {
         EXPECT_CALL(*backend, Authorize(controllerUid)).WillOnce(Return(true));
         EXPECT_CALL(*backend, GetRoleId()).WillOnce(Return(3));
         EXPECT_CALL(*backend, FetchUserCards(0, 100)).WillOnce(Return(refreshed));
+        EXPECT_CALL(*backend, FetchFuelTanks(0, 100)).WillOnce(Return(refreshedTanks));
         EXPECT_CALL(*backend, Deauthorize()).WillOnce(Return(true));
     }
 
@@ -171,6 +182,7 @@ TEST_F(CacheManagerTest, TriggerPopulationReplacesActiveTableWithFreshData) {
     EXPECT_TRUE(manager.GetLastPopulationSuccess());
     EXPECT_EQ(cache->GetCount(), 1);
     EXPECT_FALSE(cache->GetEntry("uid-initial").has_value());
+    EXPECT_EQ(cache->GetTankCount(), 1);
 
     auto entry = cache->GetEntry("uid-refreshed");
     ASSERT_TRUE(entry.has_value());

--- a/tests/controller_test.cpp
+++ b/tests/controller_test.cpp
@@ -43,6 +43,7 @@ public:
     MOCK_METHOD(const std::string&, GetLastError, (), (const, override));
     MOCK_METHOD(bool, IsNetworkError, (), (const, override));
     MOCK_METHOD(std::vector<UserCard>, FetchUserCards, (int first, int number), (override));
+    MOCK_METHOD(std::vector<FuelTank>, FetchFuelTanks, (int first, int number), (override));
     MOCK_METHOD(const std::string&, GetControllerUid, (), (const, override));
 
     std::string tokenStorage_;
@@ -197,6 +198,7 @@ protected:
     void createController(std::chrono::seconds noFlowCancelTimeout = std::chrono::seconds(30)) {
         auto backend = std::make_shared<NiceMock<MockBackend>>();
         mockBackend = backend.get();
+        ON_CALL(*mockBackend, GetControllerUid()).WillByDefault(ReturnRef(CONTROLLER_UID));
         controller = std::make_unique<Controller>(CONTROLLER_UID, backend, noFlowCancelTimeout);
 
         // Create mocks (use raw pointers as Controller takes ownership)
@@ -297,11 +299,15 @@ TEST_F(ControllerTest, Construction) {
 
 TEST_F(ControllerTest, AuthorizationFallsBackToCacheOnNetworkError) {
     ASSERT_NE(controller->getUserCache(), nullptr);
-    ASSERT_TRUE(controller->getUserCache()->UpdateEntry("offline-user", 123.0, static_cast<int>(UserRole::Customer)));
+    ASSERT_TRUE(controller->getUserCache()->BeginPopulation());
+    ASSERT_TRUE(controller->getUserCache()->AddPopulationEntry("offline-user", 123.0, static_cast<int>(UserRole::Customer)));
+    ASSERT_TRUE(controller->getUserCache()->AddPopulationTank(10, 7, "Tank-7", 700.0));
+    ASSERT_TRUE(controller->getUserCache()->CommitPopulation());
 
     EXPECT_CALL(*mockBackend, Authorize("offline-user")).WillOnce(Return(false));
     ON_CALL(*mockBackend, IsNetworkError()).WillByDefault(Return(true));
     ON_CALL(*mockBackend, FetchUserCards(_, _)).WillByDefault(Return(std::vector<UserCard>{{"offline-user", static_cast<int>(UserRole::Customer), 123.0}}));
+    ON_CALL(*mockBackend, FetchFuelTanks(_, _)).WillByDefault(Return(std::vector<FuelTank>{{10, 7, "Tank-7", 700.0}}));
 
     controller->initialize();
     controller->requestAuthorization("offline-user");
@@ -310,16 +316,21 @@ TEST_F(ControllerTest, AuthorizationFallsBackToCacheOnNetworkError) {
     EXPECT_EQ(controller->getCurrentUser().uid, "offline-user");
     EXPECT_EQ(controller->getCurrentUser().role, UserRole::Customer);
     EXPECT_DOUBLE_EQ(controller->getCurrentUser().allowance, 123.0);
-    EXPECT_TRUE(controller->getAvailableTanks().empty());
+    ASSERT_EQ(controller->getAvailableTanks().size(), 1);
+    EXPECT_EQ(controller->getAvailableTanks()[0].number, 7);
 }
 
-TEST_F(ControllerTest, CachedAuthorizationAllowsAnyPositiveTankSelection) {
+TEST_F(ControllerTest, CachedAuthorizationAllowsOnlyCachedTankSelection) {
     ASSERT_NE(controller->getUserCache(), nullptr);
-    ASSERT_TRUE(controller->getUserCache()->UpdateEntry("offline-user", 200.0, static_cast<int>(UserRole::Customer)));
+    ASSERT_TRUE(controller->getUserCache()->BeginPopulation());
+    ASSERT_TRUE(controller->getUserCache()->AddPopulationEntry("offline-user", 200.0, static_cast<int>(UserRole::Customer)));
+    ASSERT_TRUE(controller->getUserCache()->AddPopulationTank(10, 7, "Tank-7", 700.0));
+    ASSERT_TRUE(controller->getUserCache()->CommitPopulation());
 
     EXPECT_CALL(*mockBackend, Authorize("offline-user")).WillOnce(Return(false));
     ON_CALL(*mockBackend, IsNetworkError()).WillByDefault(Return(true));
     ON_CALL(*mockBackend, FetchUserCards(_, _)).WillByDefault(Return(std::vector<UserCard>{{"offline-user", static_cast<int>(UserRole::Customer), 123.0}}));
+    ON_CALL(*mockBackend, FetchFuelTanks(_, _)).WillByDefault(Return(std::vector<FuelTank>{{10, 7, "Tank-7", 700.0}}));
 
     controller->initialize();
     std::thread controllerThread([this]() { controller->run(); });
@@ -328,25 +339,31 @@ TEST_F(ControllerTest, CachedAuthorizationAllowsAnyPositiveTankSelection) {
     controller->handleCardPresented("offline-user");
     ASSERT_TRUE(waitForState(SystemState::TankSelection));
 
-    DisplayMessage msg = controller->getStateMachine().getDisplayMessage();
-    EXPECT_TRUE(msg.line3.empty());
-
     controller->handleKeyPress(KeyCode::Key9);
     controller->handleKeyPress(KeyCode::Key9);
     controller->handleKeyPress(KeyCode::KeyStart);
+    EXPECT_EQ(controller->getStateMachine().getCurrentState(), SystemState::TankSelection);
+
+    controller->clearInput();
+    controller->handleKeyPress(KeyCode::Key7);
+    controller->handleKeyPress(KeyCode::KeyStart);
     ASSERT_TRUE(waitForState(SystemState::VolumeEntry));
-    EXPECT_EQ(controller->getSelectedTank(), 99);
+    EXPECT_EQ(controller->getSelectedTank(), 7);
 
     shutdownControllerAndJoinThread(controllerThread);
 }
 
 TEST_F(ControllerTest, CachedAuthorizationRefuelGoesToBacklogAndSkipsDeauthorize) {
     ASSERT_NE(controller->getUserCache(), nullptr);
-    ASSERT_TRUE(controller->getUserCache()->UpdateEntry("offline-user", 50.0, static_cast<int>(UserRole::Customer)));
+    ASSERT_TRUE(controller->getUserCache()->BeginPopulation());
+    ASSERT_TRUE(controller->getUserCache()->AddPopulationEntry("offline-user", 50.0, static_cast<int>(UserRole::Customer)));
+    ASSERT_TRUE(controller->getUserCache()->AddPopulationTank(10, 7, "Tank-7", 700.0));
+    ASSERT_TRUE(controller->getUserCache()->CommitPopulation());
 
     EXPECT_CALL(*mockBackend, Authorize("offline-user")).WillOnce(Return(false));
     ON_CALL(*mockBackend, IsNetworkError()).WillByDefault(Return(true));
     ON_CALL(*mockBackend, FetchUserCards(_, _)).WillByDefault(Return(std::vector<UserCard>{{"offline-user", static_cast<int>(UserRole::Customer), 123.0}}));
+    ON_CALL(*mockBackend, FetchFuelTanks(_, _)).WillByDefault(Return(std::vector<FuelTank>{{10, 7, "Tank-7", 700.0}}));
     EXPECT_CALL(*mockBackend, Refuel(_, _)).Times(0);
     EXPECT_CALL(*mockBackend, Deauthorize()).Times(0);
 
@@ -370,11 +387,15 @@ TEST_F(ControllerTest, CachedAuthorizationRefuelGoesToBacklogAndSkipsDeauthorize
 
 TEST_F(ControllerTest, CachedAuthorizationIntakeGoesToBacklog) {
     ASSERT_NE(controller->getUserCache(), nullptr);
-    ASSERT_TRUE(controller->getUserCache()->UpdateEntry("offline-operator", 0.0, static_cast<int>(UserRole::Operator)));
+    ASSERT_TRUE(controller->getUserCache()->BeginPopulation());
+    ASSERT_TRUE(controller->getUserCache()->AddPopulationEntry("offline-operator", 0.0, static_cast<int>(UserRole::Operator)));
+    ASSERT_TRUE(controller->getUserCache()->AddPopulationTank(20, 11, "Tank-11", 1100.0));
+    ASSERT_TRUE(controller->getUserCache()->CommitPopulation());
 
     EXPECT_CALL(*mockBackend, Authorize("offline-operator")).WillOnce(Return(false));
     ON_CALL(*mockBackend, IsNetworkError()).WillByDefault(Return(true));
     ON_CALL(*mockBackend, FetchUserCards(_, _)).WillByDefault(Return(std::vector<UserCard>{{"offline-operator", static_cast<int>(UserRole::Operator), 0.0}}));
+    ON_CALL(*mockBackend, FetchFuelTanks(_, _)).WillByDefault(Return(std::vector<FuelTank>{{20, 11, "Tank-11", 1100.0}}));
     EXPECT_CALL(*mockBackend, Intake(_, _, _)).Times(0);
 
     controller->initialize();

--- a/tests/user_cache_test.cpp
+++ b/tests/user_cache_test.cpp
@@ -454,3 +454,40 @@ TEST_F(UserCacheTest, AtomicDeductDuringPopulation) {
     EXPECT_DOUBLE_EQ(entry1->allowance, 75.0);  // Should have deducted value
     EXPECT_EQ(entry1->roleId, 1);
 }
+
+
+TEST_F(UserCacheTest, TankPopulationStoresAndReturnsEntries) {
+    UserCache cache(dbPath_);
+
+    ASSERT_TRUE(cache.BeginPopulation());
+    EXPECT_TRUE(cache.AddPopulationTank(101, 1, "Tank-1", 1200.0));
+    EXPECT_TRUE(cache.AddPopulationTank(102, 2, "Tank-2", 1300.5));
+    ASSERT_TRUE(cache.CommitPopulation());
+
+    EXPECT_EQ(cache.GetTankCount(), 2);
+    const auto tanks = cache.GetTanks();
+    ASSERT_EQ(tanks.size(), 2);
+    EXPECT_EQ(tanks[0].idTank, 101);
+    EXPECT_EQ(tanks[0].visualNumberTank, 1);
+    EXPECT_EQ(tanks[0].nameTank, "Tank-1");
+    EXPECT_DOUBLE_EQ(tanks[0].volume, 1200.0);
+    EXPECT_EQ(tanks[1].idTank, 102);
+}
+
+TEST_F(UserCacheTest, TankPopulationReplacesPreviousSnapshot) {
+    UserCache cache(dbPath_);
+
+    ASSERT_TRUE(cache.BeginPopulation());
+    ASSERT_TRUE(cache.AddPopulationTank(101, 1, "Old", 100.0));
+    ASSERT_TRUE(cache.CommitPopulation());
+
+    ASSERT_TRUE(cache.BeginPopulation());
+    ASSERT_TRUE(cache.AddPopulationTank(202, 2, "New", 200.0));
+    ASSERT_TRUE(cache.CommitPopulation());
+
+    EXPECT_EQ(cache.GetTankCount(), 1);
+    const auto tanks = cache.GetTanks();
+    ASSERT_EQ(tanks.size(), 1);
+    EXPECT_EQ(tanks[0].visualNumberTank, 2);
+    EXPECT_EQ(tanks[0].nameTank, "New");
+}


### PR DESCRIPTION
Two correctness issues in the offline/cache session paths identified in code review.

## Changes

- **`controller.cpp` — `isTankValid()`**: Removed the `return tankNumber > 0` early-return for cache-authorized sessions. `availableTanks_` is already populated from cached tanks during offline authorization, so the same membership check now applies in both online and offline paths — preventing an out-of-cache tank number from slipping through and bypassing the capacity validation gate.

  ```cpp
  // Before: any positive tank number was "valid" offline
  bool Controller::isTankValid(TankNumber tankNumber) const {
      if (sessionAuthorizedFromCache_) {
          return tankNumber > 0;  // ← bypasses actual membership check
      }
      for (const auto& tank : availableTanks_) { ... }
  }

  // After: unified path, cache tanks are already in availableTanks_
  bool Controller::isTankValid(TankNumber tankNumber) const {
      for (const auto& tank : availableTanks_) { ... }
  }
  ```

- **`cache_manager.cpp` — tank fetch loop**: An empty `FetchFuelTanks()` response due to an error (non-empty `GetLastError()`) was previously treated as end-of-data, which would commit an empty tank snapshot and wipe the existing cache. Now distinguishes the two cases: aborts and returns `false` on error, exits the loop normally on legitimate end-of-data.