### PR TITLE
State-machine: auto-select single tank and reject authorization when none available

### DIFF
--- a/include/state_machine.h
+++ b/include/state_machine.h
@@ -57,6 +57,7 @@ private:
     
     // Transition actions
     void doAuthorization();
+    void onAuthorizationSuccess();
     void doRefuelingDataTransmission();
     void onTankSelected();
     void onVolumeEntered();

--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -216,7 +216,7 @@ void StateMachine::setupTransitions() {
     transitions_[{SystemState::Authorization, Event::CardPresented}]       = {SystemState::Authorization,     noOp};
     transitions_[{SystemState::Authorization, Event::PinEntered}]          = {SystemState::Authorization,     noOp};
     transitions_[{SystemState::Authorization, Event::InputUpdated}]        = {SystemState::Authorization,     noOp};
-    transitions_[{SystemState::Authorization, Event::AuthorizationSuccess}]= {SystemState::TankSelection,     noOp};
+    transitions_[{SystemState::Authorization, Event::AuthorizationSuccess}]= {SystemState::TankSelection,     [this]() { onAuthorizationSuccess(); }};
     transitions_[{SystemState::Authorization, Event::AuthorizationDenied}] = {SystemState::NotAuthorized,     noOp};
     transitions_[{SystemState::Authorization, Event::AuthorizationFailed}] = {SystemState::CannotAuthorize,   noOp};
     transitions_[{SystemState::Authorization, Event::TankSelected}]        = {SystemState::Authorization,     noOp};
@@ -283,7 +283,7 @@ void StateMachine::setupTransitions() {
     transitions_[{SystemState::TankSelection, Event::PinEntered}]          = {SystemState::TankSelection,     noOp};
     transitions_[{SystemState::TankSelection, Event::InputUpdated}]        = {SystemState::TankSelection,     noOp};
     transitions_[{SystemState::TankSelection, Event::AuthorizationSuccess}]= {SystemState::TankSelection,     noOp};
-    transitions_[{SystemState::TankSelection, Event::AuthorizationDenied}] = {SystemState::TankSelection,     noOp};
+    transitions_[{SystemState::TankSelection, Event::AuthorizationDenied}] = {SystemState::NotAuthorized,     noOp};
     transitions_[{SystemState::TankSelection, Event::AuthorizationFailed}] = {SystemState::TankSelection,     noOp};
     transitions_[{SystemState::TankSelection, Event::TankSelected}]        = {SystemState::VolumeEntry,       [this]() { onTankSelected();         }};
     transitions_[{SystemState::TankSelection, Event::VolumeEntered}]       = {SystemState::TankSelection,     noOp};
@@ -656,6 +656,25 @@ void StateMachine::doAuthorization() {
     // Clear sensitive input (PIN/card UID) silently 
     controller_->clearInputSilent();
     // requestAuthorization will post AuthorizationSuccess or AuthorizationFailed event
+}
+
+void StateMachine::onAuthorizationSuccess() {
+    if (!controller_) {
+        return;
+    }
+
+    const auto& availableTanks = controller_->getAvailableTanks();
+    if (availableTanks.empty()) {
+        LOG_SM_WARN("Authorization rejected: no available tanks");
+        controller_->endCurrentSession();
+        controller_->postEvent(Event::AuthorizationDenied);
+        return;
+    }
+
+    if (availableTanks.size() == 1U) {
+        LOG_SM_INFO("Single available tank detected ({}), selecting automatically", availableTanks.front().number);
+        controller_->selectTank(availableTanks.front().number);
+    }
 }
 
 void StateMachine::doRefuelingDataTransmission() {

--- a/tests/controller_test.cpp
+++ b/tests/controller_test.cpp
@@ -647,6 +647,79 @@ TEST_F(ControllerTest, AuthorizationFailureTransitionsToNotAuthorized) {
     shutdownControllerAndJoinThread(controllerThread);
 }
 
+TEST_F(ControllerTest, AuthorizationWithSingleTankAutoSelectsForCustomerRefuel) {
+    mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
+    mockBackend->allowance_ = 100.0;
+    mockBackend->price_ = 1.0;
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 42, "Tank 42"} };
+
+    EXPECT_CALL(*mockBackend, Authorize("customer-card")).WillOnce([this]() {
+        mockBackend->authorized_ = true;
+        return true;
+    });
+
+    controller->initialize();
+
+    std::thread controllerThread([this]() { controller->run(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    controller->handleCardPresented("customer-card");
+    ASSERT_TRUE(waitForState(SystemState::VolumeEntry));
+    EXPECT_EQ(controller->getSelectedTank(), 42);
+
+    shutdownControllerAndJoinThread(controllerThread);
+}
+
+TEST_F(ControllerTest, AuthorizationWithSingleTankAutoSelectsForOperatorIntake) {
+    mockBackend->roleId_ = static_cast<int>(UserRole::Operator);
+    mockBackend->allowance_ = 0.0;
+    mockBackend->price_ = 0.0;
+    mockBackend->tanksStorage_ = { BackendTankInfo{1, 7, "Tank 7"} };
+
+    EXPECT_CALL(*mockBackend, Authorize("operator-card")).WillOnce([this]() {
+        mockBackend->authorized_ = true;
+        return true;
+    });
+
+    controller->initialize();
+
+    std::thread controllerThread([this]() { controller->run(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    controller->handleCardPresented("operator-card");
+    ASSERT_TRUE(waitForState(SystemState::IntakeDirectionSelection));
+    EXPECT_EQ(controller->getSelectedTank(), 7);
+
+    shutdownControllerAndJoinThread(controllerThread);
+}
+
+TEST_F(ControllerTest, AuthorizationWithNoTanksIsRejected) {
+    mockBackend->roleId_ = static_cast<int>(UserRole::Customer);
+    mockBackend->allowance_ = 100.0;
+    mockBackend->price_ = 1.0;
+    mockBackend->tanksStorage_.clear();
+
+    EXPECT_CALL(*mockBackend, Authorize("customer-card")).WillOnce([this]() {
+        mockBackend->authorized_ = true;
+        return true;
+    });
+    EXPECT_CALL(*mockBackend, Deauthorize()).WillOnce([this]() {
+        mockBackend->authorized_ = false;
+        return true;
+    });
+
+    controller->initialize();
+
+    std::thread controllerThread([this]() { controller->run(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    controller->handleCardPresented("customer-card");
+    ASSERT_TRUE(waitForState(SystemState::NotAuthorized));
+    EXPECT_EQ(controller->getSelectedTank(), 0);
+
+    shutdownControllerAndJoinThread(controllerThread);
+}
+
 TEST_F(ControllerTest, NotAuthorizedCancelAndTimeoutReturnToWaiting) {
     EXPECT_CALL(*mockBackend, Authorize("denied-card")).Times(2).WillRepeatedly(Return(false));
     EXPECT_CALL(*mockBackend, IsNetworkError()).WillRepeatedly(Return(false));


### PR DESCRIPTION
### Motivation
- Simplify user flow by automatically selecting the only available tank after authorization so users/operators skip manual tank selection.
- Ensure authorization is rejected when the backend provides no tanks to avoid leaving a session in an unusable TankSelection state.

### Description
- Added a new state-machine transition action `onAuthorizationSuccess()` and wired it into the `AuthorizationSuccess` transition from `Authorization` in `StateMachine`.
- Implemented logic in `onAuthorizationSuccess()` to end the session and post `AuthorizationDenied` when `availableTanks` is empty, and to call `controller_->selectTank(...)` when exactly one tank is available (auto-selection works for both customer/refuel and operator/intake flows because `selectTank()` triggers role-specific events).
- Adjusted the `TankSelection` transition for `AuthorizationDenied` to move to `NotAuthorized` so the no-tank rejection flows to the expected state.
- Added unit tests covering the new behaviors: single-tank auto-selection for customer refuel and operator intake, and no-tanks authorization rejection; tests were added/updated in `tests/controller_test.cpp`.
- Files changed: `include/state_machine.h`, `src/state_machine.cpp`, `tests/controller_test.cpp`.

### Testing
- Built the project with tests enabled using `cmake -S . -B build -G Ninja -DENABLE_TESTING=ON && cmake --build build` which completed successfully.
- Ran focused controller tests with `./build/bin/fuelflux_tests --gtest_filter='ControllerTest.AuthorizationWithSingleTankAutoSelectsForCustomerRefuel:ControllerTest.AuthorizationWithSingleTankAutoSelectsForOperatorIntake:ControllerTest.AuthorizationWithNoTanksIsRejected:ControllerTest.AuthorizationFailureTransitionsToNotAuthorized'` and observed all 4 targeted tests passed.
- Also exercised the same four tests via `ctest -R` in the build directory and verified they passed (100% for the focused set).
- No repository linter/format target was found to run (checked CMake targets for lint/format/tidy).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d65e20507c8321a4a75b2664fb3dec)